### PR TITLE
Improve item selection UI

### DIFF
--- a/src/components/MultiSelectFilter.tsx
+++ b/src/components/MultiSelectFilter.tsx
@@ -12,6 +12,7 @@ import type { CheckboxCheckedState } from "@radix-ui/react-checkbox";
 interface MultiSelectOption {
   id: string;
   name: string;
+  image?: string;
   indent?: boolean;
   header?: boolean;
   checkState?: CheckboxCheckedState;
@@ -123,6 +124,13 @@ export function MultiSelectFilter({ placeholder, options, selectedValues, onSele
                     }
                   }}
                 />
+                {option.image && (
+                  <img
+                    src={option.image}
+                    alt={option.name}
+                    className="w-8 h-8 object-cover rounded"
+                  />
+                )}
                 <span className={`text-sm ${option.header ? 'font-medium text-slate-600' : ''}`}>{option.name}</span>
               </div>
             );

--- a/src/pages/AllItems.tsx
+++ b/src/pages/AllItems.tsx
@@ -141,7 +141,7 @@ const AllItems = () => {
     URL.revokeObjectURL(url);
   };
 
-  const itemOptions = items.map(item => ({ id: item.id.toString(), name: item.title }));
+  const itemOptions = sortedItems.map(item => ({ id: item.id.toString(), name: item.title, image: item.image }));
   const selectedItems = items.filter(item => selectedIds.includes(item.id.toString()));
 
   return (

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -10,6 +10,7 @@ import { ItemsTable } from "@/components/ItemsTable";
 import { ItemDetailDialog } from "@/components/ItemDetailDialog";
 import { ItemHistoryDialog } from "@/components/ItemHistoryDialog";
 import { EmptyState } from "@/components/EmptyState";
+import { MultiSelectFilter } from "@/components/MultiSelectFilter";
 import { sampleItems } from "@/data/sampleData";
 import { fetchInventory, deleteInventoryItem } from "@/lib/api";
 import { InventoryItem } from "@/types/inventory";
@@ -31,6 +32,7 @@ const CategoryPage = () => {
   const [items, setItems] = useState<InventoryItem[]>(sampleItems);
   const [selectedItem, setSelectedItem] = useState<InventoryItem | null>(null);
   const [historyItem, setHistoryItem] = useState<InventoryItem | null>(null);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [sortField, setSortField] = useState<string>("");
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const { categories, houses } = useSettingsState();
@@ -150,6 +152,9 @@ const CategoryPage = () => {
     URL.revokeObjectURL(url);
   };
 
+  const itemOptions = sortedItems.map(item => ({ id: item.id.toString(), name: item.title, image: item.image }));
+  const selectedItems = items.filter(item => selectedIds.includes(item.id.toString()));
+
   return (
     <SidebarProvider>
       <div className="min-h-screen flex w-full bg-slate-50">
@@ -180,6 +185,26 @@ const CategoryPage = () => {
               onDownloadCSV={downloadCSV}
               permanentCategory={categoryId}
             />
+
+            <div className="max-w-md mb-6">
+              <MultiSelectFilter
+                placeholder="Select items"
+                options={itemOptions}
+                selectedValues={selectedIds}
+                onSelectionChange={setSelectedIds}
+              />
+            </div>
+
+            {selectedItems.length > 0 && (
+              <div className="mb-6 space-y-2">
+                <h3 className="font-medium text-slate-700">Selected Items</h3>
+                <ul className="list-disc pl-5 space-y-1">
+                  {selectedItems.map(item => (
+                    <li key={item.id}>{item.title}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
 
             <div className="mb-6">
               <p className="text-slate-600">

--- a/src/pages/HousePage.tsx
+++ b/src/pages/HousePage.tsx
@@ -11,6 +11,7 @@ import { ItemsTable } from "@/components/ItemsTable";
 import { ItemDetailDialog } from "@/components/ItemDetailDialog";
 import { ItemHistoryDialog } from "@/components/ItemHistoryDialog";
 import { EmptyState } from "@/components/EmptyState";
+import { MultiSelectFilter } from "@/components/MultiSelectFilter";
 import { sampleItems } from "@/data/sampleData";
 import { fetchInventory, deleteInventoryItem } from "@/lib/api";
 import { InventoryItem } from "@/types/inventory";
@@ -32,6 +33,7 @@ const HousePage = () => {
   const [items, setItems] = useState<InventoryItem[]>(sampleItems);
   const [selectedItem, setSelectedItem] = useState<InventoryItem | null>(null);
   const [historyItem, setHistoryItem] = useState<InventoryItem | null>(null);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [sortField, setSortField] = useState<string>("");
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const { houses, categories } = useSettingsState();
@@ -152,6 +154,9 @@ const HousePage = () => {
     setSortDirection(direction);
   };
 
+  const itemOptions = sortedItems.map(item => ({ id: item.id.toString(), name: item.title, image: item.image }));
+  const selectedItems = items.filter(item => selectedIds.includes(item.id.toString()));
+
   return (
     <SidebarProvider>
       <div className="min-h-screen flex w-full bg-slate-50">
@@ -182,6 +187,26 @@ const HousePage = () => {
               onDownloadCSV={downloadCSV}
               permanentHouse={houseId}
             />
+
+            <div className="max-w-md mb-6">
+              <MultiSelectFilter
+                placeholder="Select items"
+                options={itemOptions}
+                selectedValues={selectedIds}
+                onSelectionChange={setSelectedIds}
+              />
+            </div>
+
+            {selectedItems.length > 0 && (
+              <div className="mb-6 space-y-2">
+                <h3 className="font-medium text-slate-700">Selected Items</h3>
+                <ul className="list-disc pl-5 space-y-1">
+                  {selectedItems.map(item => (
+                    <li key={item.id}>{item.title}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
 
             <div className="mb-6">
               <p className="text-slate-600">


### PR DESCRIPTION
## Summary
- show images in multi-select filter
- include item selector on category and house pages
- use grid items as options for selectors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_686cd3cbc18c8325a4dbd8af82f055a5