### PR TITLE
Add item history restore capability

### DIFF
--- a/src/components/ItemHistoryDialog.tsx
+++ b/src/components/ItemHistoryDialog.tsx
@@ -1,13 +1,18 @@
+import { useState } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { ItemDetailDialog } from "@/components/ItemDetailDialog";
 import type { InventoryItem } from "@/types/inventory";
 
 interface ItemHistoryDialogProps {
   item: InventoryItem | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onRestore?: (version: InventoryItem) => void;
 }
 
-export function ItemHistoryDialog({ item, open, onOpenChange }: ItemHistoryDialogProps) {
+export function ItemHistoryDialog({ item, open, onOpenChange, onRestore }: ItemHistoryDialogProps) {
+  const [versionItem, setVersionItem] = useState<InventoryItem | null>(null);
   if (!item || !item.history || item.history.length === 0) return null;
 
   return (
@@ -25,6 +30,7 @@ export function ItemHistoryDialog({ item, open, onOpenChange }: ItemHistoryDialo
                 <th className="px-4 py-2 text-left">Artist</th>
                 <th className="px-4 py-2 text-left">Category</th>
                 <th className="px-4 py-2 text-left">Location</th>
+                <th className="px-4 py-2 text-left">Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -37,11 +43,26 @@ export function ItemHistoryDialog({ item, open, onOpenChange }: ItemHistoryDialo
                   <td className="px-4 py-2 capitalize">
                     {[h.house, h.room].filter(Boolean).join(' / ') || '-'}
                   </td>
+                  <td className="px-4 py-2 space-x-2">
+                    <Button size="sm" variant="outline" onClick={() => setVersionItem(h)}>
+                      View
+                    </Button>
+                    {onRestore && (
+                      <Button size="sm" onClick={() => onRestore(h)}>
+                        Restore
+                      </Button>
+                    )}
+                  </td>
                 </tr>
               ))}
             </tbody>
           </table>
         </div>
+        <ItemDetailDialog
+          item={versionItem}
+          open={!!versionItem}
+          onOpenChange={(open) => !open && setVersionItem(null)}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -86,6 +86,10 @@ export async function updateInventoryItem(id: number | string, updates: Inventor
   }
 }
 
+export async function restoreInventoryItem(id: number | string, version: InventoryItem) {
+  return updateInventoryItem(id, version);
+}
+
 export async function deleteInventoryItem(id: number | string) {
   try {
     const response = await fetch(`${API_URL}/items/${id}`, {

--- a/src/pages/AllItems.tsx
+++ b/src/pages/AllItems.tsx
@@ -13,7 +13,7 @@ import { ItemHistoryDialog } from "@/components/ItemHistoryDialog";
 import { EmptyState } from "@/components/EmptyState";
 import { MultiSelectFilter } from "@/components/MultiSelectFilter";
 import { sampleItems } from "@/data/sampleData";
-import { fetchInventory, deleteInventoryItem } from "@/lib/api";
+import { fetchInventory, deleteInventoryItem, restoreInventoryItem } from "@/lib/api";
 import { InventoryItem } from "@/types/inventory";
 import { useSettingsState } from "@/hooks/useSettingsState";
 import { sortInventoryItems } from "@/lib/sortUtils";
@@ -65,6 +65,27 @@ const AllItems = () => {
 
   const handleHistory = (item: InventoryItem) => {
     setHistoryItem(item);
+  };
+
+  const handleRestore = (version: InventoryItem) => {
+    if (!historyItem) return;
+    restoreInventoryItem(historyItem.id, version)
+      .then(updated => {
+        setItems(prev => prev.map(i => i.id === updated.id ? updated : i));
+        setHistoryItem(updated);
+        setSelectedItem(updated);
+        toast({
+          title: 'Item restored',
+          description: 'The selected version has been restored',
+        });
+      })
+      .catch(() => {
+        toast({
+          title: 'Error restoring item',
+          description: 'There was a problem restoring this version',
+          variant: 'destructive',
+        });
+      });
   };
 
   useEffect(() => {
@@ -228,6 +249,7 @@ const AllItems = () => {
               item={historyItem}
               open={!!historyItem}
               onOpenChange={(open) => !open && setHistoryItem(null)}
+              onRestore={handleRestore}
             />
           </main>
         </div>

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -11,7 +11,7 @@ import { ItemDetailDialog } from "@/components/ItemDetailDialog";
 import { ItemHistoryDialog } from "@/components/ItemHistoryDialog";
 import { EmptyState } from "@/components/EmptyState";
 import { sampleItems } from "@/data/sampleData";
-import { fetchInventory, deleteInventoryItem } from "@/lib/api";
+import { fetchInventory, deleteInventoryItem, restoreInventoryItem } from "@/lib/api";
 import { InventoryItem } from "@/types/inventory";
 import { useSettingsState } from "@/hooks/useSettingsState";
 import { sortInventoryItems } from "@/lib/sortUtils";
@@ -63,6 +63,27 @@ const CategoryPage = () => {
 
   const handleHistory = (item: InventoryItem) => {
     setHistoryItem(item);
+  };
+
+  const handleRestore = (version: InventoryItem) => {
+    if (!historyItem) return;
+    restoreInventoryItem(historyItem.id, version)
+      .then(updated => {
+        setItems(prev => prev.map(i => i.id === updated.id ? updated : i));
+        setHistoryItem(updated);
+        setSelectedItem(updated);
+        toast({
+          title: 'Item restored',
+          description: 'The selected version has been restored',
+        });
+      })
+      .catch(() => {
+        toast({
+          title: 'Error restoring item',
+          description: 'There was a problem restoring this version',
+          variant: 'destructive',
+        });
+      });
   };
 
   useEffect(() => {
@@ -215,6 +236,7 @@ const CategoryPage = () => {
               item={historyItem}
               open={!!historyItem}
               onOpenChange={(open) => !open && setHistoryItem(null)}
+              onRestore={handleRestore}
             />
           </main>
         </div>

--- a/src/pages/HousePage.tsx
+++ b/src/pages/HousePage.tsx
@@ -12,7 +12,7 @@ import { ItemDetailDialog } from "@/components/ItemDetailDialog";
 import { ItemHistoryDialog } from "@/components/ItemHistoryDialog";
 import { EmptyState } from "@/components/EmptyState";
 import { sampleItems } from "@/data/sampleData";
-import { fetchInventory, deleteInventoryItem } from "@/lib/api";
+import { fetchInventory, deleteInventoryItem, restoreInventoryItem } from "@/lib/api";
 import { InventoryItem } from "@/types/inventory";
 import { useSettingsState } from "@/hooks/useSettingsState";
 import { sortInventoryItems } from "@/lib/sortUtils";
@@ -64,6 +64,27 @@ const HousePage = () => {
 
   const handleHistory = (item: InventoryItem) => {
     setHistoryItem(item);
+  };
+
+  const handleRestore = (version: InventoryItem) => {
+    if (!historyItem) return;
+    restoreInventoryItem(historyItem.id, version)
+      .then(updated => {
+        setItems(prev => prev.map(i => i.id === updated.id ? updated : i));
+        setHistoryItem(updated);
+        setSelectedItem(updated);
+        toast({
+          title: 'Item restored',
+          description: 'The selected version has been restored',
+        });
+      })
+      .catch(() => {
+        toast({
+          title: 'Error restoring item',
+          description: 'There was a problem restoring this version',
+          variant: 'destructive',
+        });
+      });
   };
 
   useEffect(() => {
@@ -217,6 +238,7 @@ const HousePage = () => {
               item={historyItem}
               open={!!historyItem}
               onOpenChange={(open) => !open && setHistoryItem(null)}
+              onRestore={handleRestore}
             />
           </main>
         </div>


### PR DESCRIPTION
## Summary
- extend `ItemHistoryDialog` with actions to view and restore versions
- add `restoreInventoryItem` helper in API
- implement restore logic in AllItems, CategoryPage and HousePage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686cd4e28ffc8325bfa4648b3510f370