### PR TITLE
Enable direct item selection

### DIFF
--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -1,22 +1,46 @@
 
 import { Card, CardContent } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { cn } from "@/lib/utils";
 import { InventoryItem } from "@/types/inventory";
 
 interface ItemCardProps {
   item: InventoryItem;
   onClick?: (item: InventoryItem) => void;
+  selected?: boolean;
+  onSelect?: (shift: boolean) => void;
 }
 
-export function ItemCard({ item, onClick }: ItemCardProps) {
-  const handleClick = () => {
-    if (onClick) {
-      onClick(item);
+export function ItemCard({ item, onClick, selected, onSelect }: ItemCardProps) {
+  const handleClick = (e: React.MouseEvent) => {
+    if (e.shiftKey && onSelect) {
+      onSelect(true);
+      return;
     }
+    onClick?.(item);
+  };
+
+  const handleCheckbox = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onSelect?.(false);
   };
 
   return (
-    <Card className="group hover:shadow-lg transition-all duration-300 cursor-pointer" onClick={handleClick}>
+    <Card
+      className={cn(
+        "relative group hover:shadow-lg transition-all duration-300 cursor-pointer",
+        selected && "ring-2 ring-primary"
+      )}
+      onClick={handleClick}
+    >
       <CardContent className="p-0">
+        {onSelect && (
+          <Checkbox
+            checked={selected}
+            onClick={handleCheckbox}
+            className="absolute top-2 left-2 z-10 bg-white rounded-sm"
+          />
+        )}
         <div className="aspect-square overflow-hidden rounded-t-lg">
           <img
             src={item.image}

--- a/src/components/ItemsGrid.tsx
+++ b/src/components/ItemsGrid.tsx
@@ -1,17 +1,46 @@
 
+import { useRef } from "react";
 import { ItemCard } from "./ItemCard";
 import { InventoryItem } from "@/types/inventory";
 
 interface ItemsGridProps {
   items: InventoryItem[];
   onItemClick?: (item: InventoryItem) => void;
+  selectedIds?: string[];
+  onSelectionChange?: (ids: string[]) => void;
 }
 
-export function ItemsGrid({ items, onItemClick }: ItemsGridProps) {
+export function ItemsGrid({ items, onItemClick, selectedIds = [], onSelectionChange }: ItemsGridProps) {
+  const lastIndex = useRef<number | null>(null);
+
+  const toggle = (id: string, index: number, shift: boolean) => {
+    if (!onSelectionChange) return;
+    let newIds = [...selectedIds];
+    if (shift && lastIndex.current !== null) {
+      const start = Math.min(lastIndex.current, index);
+      const end = Math.max(lastIndex.current, index);
+      const range = items.slice(start, end + 1).map(i => i.id.toString());
+      range.forEach(rid => {
+        if (!newIds.includes(rid)) newIds.push(rid);
+      });
+    } else {
+      if (newIds.includes(id)) newIds = newIds.filter(i => i !== id);
+      else newIds.push(id);
+      lastIndex.current = index;
+    }
+    onSelectionChange(newIds);
+  };
+
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-      {items.map((item) => (
-        <ItemCard key={item.id} item={item} onClick={onItemClick} />
+      {items.map((item, idx) => (
+        <ItemCard
+          key={item.id}
+          item={item}
+          onClick={onItemClick}
+          selected={selectedIds.includes(item.id.toString())}
+          onSelect={(shift) => toggle(item.id.toString(), idx, shift)}
+        />
       ))}
     </div>
   );

--- a/src/pages/AllItems.tsx
+++ b/src/pages/AllItems.tsx
@@ -11,7 +11,6 @@ import { ItemsTable } from "@/components/ItemsTable";
 import { ItemDetailDialog } from "@/components/ItemDetailDialog";
 import { ItemHistoryDialog } from "@/components/ItemHistoryDialog";
 import { EmptyState } from "@/components/EmptyState";
-import { MultiSelectFilter } from "@/components/MultiSelectFilter";
 import { sampleItems } from "@/data/sampleData";
 import { fetchInventory, deleteInventoryItem } from "@/lib/api";
 import { InventoryItem } from "@/types/inventory";
@@ -141,8 +140,6 @@ const AllItems = () => {
     URL.revokeObjectURL(url);
   };
 
-  const itemOptions = sortedItems.map(item => ({ id: item.id.toString(), name: item.title, image: item.image }));
-  const selectedItems = items.filter(item => selectedIds.includes(item.id.toString()));
 
   return (
     <SidebarProvider>
@@ -174,23 +171,15 @@ const AllItems = () => {
               onDownloadCSV={downloadCSV}
             />
 
-            <div className="max-w-md mb-6">
-              <MultiSelectFilter
-                placeholder="Select items"
-                options={itemOptions}
-                selectedValues={selectedIds}
-                onSelectionChange={setSelectedIds}
-              />
-            </div>
-
-            {selectedItems.length > 0 && (
-              <div className="mb-6 space-y-2">
-                <h3 className="font-medium text-slate-700">Selected Items</h3>
-                <ul className="list-disc pl-5 space-y-1">
-                  {selectedItems.map(item => (
-                    <li key={item.id}>{item.title}</li>
-                  ))}
-                </ul>
+            {selectedIds.length > 0 && (
+              <div className="mb-6 flex items-center justify-between bg-blue-100 border border-blue-200 text-blue-800 px-4 py-2 rounded">
+                <span className="text-sm font-medium">{selectedIds.length} item{selectedIds.length === 1 ? '' : 's'} selected</span>
+                <button
+                  className="text-sm underline"
+                  onClick={() => setSelectedIds([])}
+                >
+                  Clear
+                </button>
               </div>
             )}
 
@@ -203,16 +192,28 @@ const AllItems = () => {
             {sortedItems.length === 0 ? (
               <EmptyState />
             ) : viewMode === "grid" ? (
-              <ItemsGrid items={sortedItems} onItemClick={setSelectedItem} />
+              <ItemsGrid
+                items={sortedItems}
+                onItemClick={setSelectedItem}
+                selectedIds={selectedIds}
+                onSelectionChange={setSelectedIds}
+              />
             ) : viewMode === "list" ? (
-              <ItemsList items={sortedItems} onItemClick={setSelectedItem} />
+              <ItemsList
+                items={sortedItems}
+                onItemClick={setSelectedItem}
+                selectedIds={selectedIds}
+                onSelectionChange={setSelectedIds}
+              />
             ) : (
-              <ItemsTable 
-                items={sortedItems} 
+              <ItemsTable
+                items={sortedItems}
                 onItemClick={setSelectedItem}
                 onSort={handleSort}
                 sortField={sortField}
                 sortDirection={sortDirection}
+                selectedIds={selectedIds}
+                onSelectionChange={setSelectedIds}
               />
             )}
 

--- a/src/pages/HousePage.tsx
+++ b/src/pages/HousePage.tsx
@@ -11,7 +11,6 @@ import { ItemsTable } from "@/components/ItemsTable";
 import { ItemDetailDialog } from "@/components/ItemDetailDialog";
 import { ItemHistoryDialog } from "@/components/ItemHistoryDialog";
 import { EmptyState } from "@/components/EmptyState";
-import { MultiSelectFilter } from "@/components/MultiSelectFilter";
 import { sampleItems } from "@/data/sampleData";
 import { fetchInventory, deleteInventoryItem } from "@/lib/api";
 import { InventoryItem } from "@/types/inventory";
@@ -154,8 +153,6 @@ const HousePage = () => {
     setSortDirection(direction);
   };
 
-  const itemOptions = sortedItems.map(item => ({ id: item.id.toString(), name: item.title, image: item.image }));
-  const selectedItems = items.filter(item => selectedIds.includes(item.id.toString()));
 
   return (
     <SidebarProvider>
@@ -188,23 +185,15 @@ const HousePage = () => {
               permanentHouse={houseId}
             />
 
-            <div className="max-w-md mb-6">
-              <MultiSelectFilter
-                placeholder="Select items"
-                options={itemOptions}
-                selectedValues={selectedIds}
-                onSelectionChange={setSelectedIds}
-              />
-            </div>
-
-            {selectedItems.length > 0 && (
-              <div className="mb-6 space-y-2">
-                <h3 className="font-medium text-slate-700">Selected Items</h3>
-                <ul className="list-disc pl-5 space-y-1">
-                  {selectedItems.map(item => (
-                    <li key={item.id}>{item.title}</li>
-                  ))}
-                </ul>
+            {selectedIds.length > 0 && (
+              <div className="mb-6 flex items-center justify-between bg-blue-100 border border-blue-200 text-blue-800 px-4 py-2 rounded">
+                <span className="text-sm font-medium">{selectedIds.length} item{selectedIds.length === 1 ? '' : 's'} selected</span>
+                <button
+                  className="text-sm underline"
+                  onClick={() => setSelectedIds([])}
+                >
+                  Clear
+                </button>
               </div>
             )}
 
@@ -217,9 +206,19 @@ const HousePage = () => {
             {sortedItems.length === 0 ? (
               <EmptyState />
             ) : viewMode === "grid" ? (
-              <ItemsGrid items={sortedItems} onItemClick={setSelectedItem} />
+              <ItemsGrid
+                items={sortedItems}
+                onItemClick={setSelectedItem}
+                selectedIds={selectedIds}
+                onSelectionChange={setSelectedIds}
+              />
             ) : viewMode === "list" ? (
-              <ItemsList items={sortedItems} onItemClick={setSelectedItem} />
+              <ItemsList
+                items={sortedItems}
+                onItemClick={setSelectedItem}
+                selectedIds={selectedIds}
+                onSelectionChange={setSelectedIds}
+              />
             ) : (
               <ItemsTable
                 items={sortedItems}
@@ -227,6 +226,8 @@ const HousePage = () => {
                 onSort={handleSort}
                 sortField={sortField}
                 sortDirection={sortDirection}
+                selectedIds={selectedIds}
+                onSelectionChange={setSelectedIds}
               />
             )}
 


### PR DESCRIPTION
## Summary
- add checkbox and highlight features to ItemCard
- support selecting items with shift+click in ItemsGrid
- enable selection with blue highlight in ItemsList
- add row checkboxes and selection handling to ItemsTable
- drop MultiSelectFilter and show selection banner in AllItems and HousePage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_b_686d642d4cc88325bd94bc73eca7ed42