### PR TITLE
Add new filters and UI improvements

### DIFF
--- a/src/components/AddItemLocationValuation.tsx
+++ b/src/components/AddItemLocationValuation.tsx
@@ -41,7 +41,7 @@ export function AddItemLocationValuation({ formData, setFormData }: AddItemLocat
       />
 
       <div>
-        <Label htmlFor="condition">Condition *</Label>
+        <Label htmlFor="condition">Condition</Label>
         <Select value={formData.condition} onValueChange={(value) => setFormData({ ...formData, condition: value })}>
           <SelectTrigger
             className={formData.condition ? undefined : "text-muted-foreground"}

--- a/src/components/ItemHistoryDialog.tsx
+++ b/src/components/ItemHistoryDialog.tsx
@@ -43,7 +43,7 @@ export function ItemHistoryDialog({ item, open, onOpenChange, onRestore }: ItemH
                   <td className="px-4 py-2 capitalize">
                     {[h.house, h.room].filter(Boolean).join(' / ') || '-'}
                   </td>
-                  <td className="px-4 py-2 space-x-2">
+                  <td className="px-4 py-2 space-x-2 text-right whitespace-nowrap">
                     <Button size="sm" variant="outline" onClick={() => setVersionItem(h)}>
                       View
                     </Button>

--- a/src/components/SearchFilters.tsx
+++ b/src/components/SearchFilters.tsx
@@ -4,6 +4,9 @@ import { FilterHeader } from "@/components/filters/FilterHeader";
 import { SearchInput } from "@/components/filters/SearchInput";
 import { CombinedCategoryFilter } from "@/components/filters/CombinedCategoryFilter";
 import { CombinedLocationFilter } from "@/components/filters/CombinedLocationFilter";
+import { YearFilter } from "@/components/filters/YearFilter";
+import { ArtistFilter } from "@/components/filters/ArtistFilter";
+import { ValuationRangeFilter } from "@/components/filters/ValuationRangeFilter";
 import { AppliedFilters } from "@/components/filters/AppliedFilters";
 import { cn } from "@/lib/utils";
 
@@ -18,6 +21,14 @@ interface SearchFiltersProps {
   setSelectedHouse: (houses: string[]) => void;
   selectedRoom: string[];
   setSelectedRoom: (rooms: string[]) => void;
+  yearOptions: string[];
+  selectedYear: string[];
+  setSelectedYear: (years: string[]) => void;
+  artistOptions: string[];
+  selectedArtist: string[];
+  setSelectedArtist: (artists: string[]) => void;
+  valuationRange: { min?: number; max?: number };
+  setValuationRange: (range: { min?: number; max?: number }) => void;
   viewMode: ViewMode;
   setViewMode: (mode: ViewMode) => void;
   onDownloadCSV?: () => void;
@@ -36,6 +47,14 @@ export function SearchFilters({
   setSelectedHouse,
   selectedRoom,
   setSelectedRoom,
+  yearOptions,
+  selectedYear,
+  setSelectedYear,
+  artistOptions,
+  selectedArtist,
+  setSelectedArtist,
+  valuationRange,
+  setValuationRange,
   viewMode,
   setViewMode,
   onDownloadCSV,
@@ -47,7 +66,11 @@ export function SearchFilters({
     selectedCategory.length +
     selectedSubcategory.length +
     selectedHouse.length +
-    selectedRoom.length;
+    selectedRoom.length +
+    selectedYear.length +
+    selectedArtist.length +
+    (valuationRange.min ? 1 : 0) +
+    (valuationRange.max ? 1 : 0);
   return (
     <div className="mb-8 space-y-6">
       {/* Header with title and view controls */}
@@ -89,6 +112,29 @@ export function SearchFilters({
             permanentHouse={permanentHouse}
           />
 
+          <div className="md:col-span-2">
+            <YearFilter
+              yearOptions={yearOptions}
+              selectedYear={selectedYear}
+              setSelectedYear={setSelectedYear}
+            />
+          </div>
+
+          <div className="md:col-span-2">
+            <ArtistFilter
+              artistOptions={artistOptions}
+              selectedArtist={selectedArtist}
+              setSelectedArtist={setSelectedArtist}
+            />
+          </div>
+
+          <div className="md:col-span-2">
+            <ValuationRangeFilter
+              range={valuationRange}
+              setRange={setValuationRange}
+            />
+          </div>
+
         </div>
       </div>
 
@@ -104,6 +150,12 @@ export function SearchFilters({
         setSelectedHouse={setSelectedHouse}
         selectedRoom={selectedRoom}
         setSelectedRoom={setSelectedRoom}
+        selectedYear={selectedYear}
+        setSelectedYear={setSelectedYear}
+        selectedArtist={selectedArtist}
+        setSelectedArtist={setSelectedArtist}
+        valuationRange={valuationRange}
+        setValuationRange={setValuationRange}
         permanentCategory={permanentCategory}
         permanentHouse={permanentHouse}
       />

--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -15,6 +15,12 @@ interface AppliedFiltersProps {
   setSelectedHouse: (houses: string[]) => void;
   selectedRoom: string[];
   setSelectedRoom: (rooms: string[]) => void;
+  selectedYear: string[];
+  setSelectedYear: (years: string[]) => void;
+  selectedArtist: string[];
+  setSelectedArtist: (artists: string[]) => void;
+  valuationRange: { min?: number; max?: number };
+  setValuationRange: (range: { min?: number; max?: number }) => void;
   permanentCategory?: string;
   permanentHouse?: string;
 }
@@ -30,6 +36,12 @@ export function AppliedFilters({
   setSelectedHouse,
   selectedRoom,
   setSelectedRoom,
+  selectedYear,
+  setSelectedYear,
+  selectedArtist,
+  setSelectedArtist,
+  valuationRange,
+  setValuationRange,
   permanentCategory,
   permanentHouse,
 }: AppliedFiltersProps) {
@@ -53,7 +65,13 @@ export function AppliedFilters({
       case 'room':
         setSelectedRoom(selectedRoom.filter(r => r !== value));
         break;
-      }
+      case 'year':
+        setSelectedYear(selectedYear.filter(y => y !== value));
+        break;
+      case 'artist':
+        setSelectedArtist(selectedArtist.filter(a => a !== value));
+        break;
+    }
   };
 
   const clearAllFilters = () => {
@@ -65,11 +83,16 @@ export function AppliedFilters({
       setSelectedHouse([]);
     }
     setSelectedRoom([]);
+    setSelectedYear([]);
+    setSelectedArtist([]);
+    setValuationRange({});
     setSearchTerm("");
   };
 
   const hasActiveFilters = selectedCategory.length > 0 || selectedHouse.length > 0 ||
                           selectedSubcategory.length > 0 || selectedRoom.length > 0 ||
+                          selectedYear.length > 0 || selectedArtist.length > 0 ||
+                          valuationRange.min !== undefined || valuationRange.max !== undefined ||
                           searchTerm.length > 0;
 
   if (!hasActiveFilters) return null;
@@ -154,6 +177,33 @@ export function AppliedFilters({
             </Badge>
           );
         })}
+        {selectedYear.map(year => (
+          <Badge key={year} variant="secondary" className="px-3 py-1">
+            Year: {year}
+            <X
+              className="w-3 h-3 ml-2 cursor-pointer hover:text-destructive"
+              onClick={() => clearFilter('year', year)}
+            />
+          </Badge>
+        ))}
+        {selectedArtist.map(artist => (
+          <Badge key={artist} variant="secondary" className="px-3 py-1">
+            Artist: {artist}
+            <X
+              className="w-3 h-3 ml-2 cursor-pointer hover:text-destructive"
+              onClick={() => clearFilter('artist', artist)}
+            />
+          </Badge>
+        ))}
+        {(valuationRange.min !== undefined || valuationRange.max !== undefined) && (
+          <Badge variant="secondary" className="px-3 py-1">
+            Valuation: {valuationRange.min ?? 0} - {valuationRange.max ?? '∞'}
+            <X
+              className="w-3 h-3 ml-2 cursor-pointer hover:text-destructive"
+              onClick={() => setValuationRange({})}
+            />
+          </Badge>
+        )}
       </div>
     </div>
   );

--- a/src/components/filters/ArtistFilter.tsx
+++ b/src/components/filters/ArtistFilter.tsx
@@ -1,0 +1,22 @@
+import { MultiSelectFilter } from "@/components/MultiSelectFilter";
+
+interface ArtistFilterProps {
+  artistOptions: string[];
+  selectedArtist: string[];
+  setSelectedArtist: (artists: string[]) => void;
+}
+
+export function ArtistFilter({ artistOptions, selectedArtist, setSelectedArtist }: ArtistFilterProps) {
+  const options = artistOptions.map(a => ({ id: a, name: a }));
+  return (
+    <div>
+      <label className="block text-sm font-medium text-slate-700 mb-2">Artist</label>
+      <MultiSelectFilter
+        placeholder="Select artists"
+        options={options}
+        selectedValues={selectedArtist}
+        onSelectionChange={setSelectedArtist}
+      />
+    </div>
+  );
+}

--- a/src/components/filters/ValuationRangeFilter.tsx
+++ b/src/components/filters/ValuationRangeFilter.tsx
@@ -1,0 +1,33 @@
+import { Input } from "@/components/ui/input";
+
+interface ValuationRange {
+  min?: number;
+  max?: number;
+}
+
+interface ValuationRangeFilterProps {
+  range: ValuationRange;
+  setRange: (range: ValuationRange) => void;
+}
+
+export function ValuationRangeFilter({ range, setRange }: ValuationRangeFilterProps) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-slate-700 mb-2">Valuation Range</label>
+      <div className="flex gap-2">
+        <Input
+          type="number"
+          placeholder="Min"
+          value={range.min ?? ""}
+          onChange={(e) => setRange({ ...range, min: e.target.value ? Number(e.target.value) : undefined })}
+        />
+        <Input
+          type="number"
+          placeholder="Max"
+          value={range.max ?? ""}
+          onChange={(e) => setRange({ ...range, max: e.target.value ? Number(e.target.value) : undefined })}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -24,7 +24,7 @@ const SelectTrigger = React.forwardRef<
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown className="h-4 w-4 text-slate-700" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ))

--- a/src/pages/AllItems.tsx
+++ b/src/pages/AllItems.tsx
@@ -27,6 +27,9 @@ const AllItems = () => {
   const [selectedSubcategory, setSelectedSubcategory] = useState<string[]>([]);
   const [selectedHouse, setSelectedHouse] = useState<string[]>([]);
   const [selectedRoom, setSelectedRoom] = useState<string[]>([]); // stores "houseId|roomId"
+  const [selectedYear, setSelectedYear] = useState<string[]>([]);
+  const [selectedArtist, setSelectedArtist] = useState<string[]>([]);
+  const [valuationRange, setValuationRange] = useState<{ min?: number; max?: number }>({});
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const [items, setItems] = useState<InventoryItem[]>(sampleItems);
   const [selectedItem, setSelectedItem] = useState<InventoryItem | null>(null);
@@ -36,6 +39,9 @@ const AllItems = () => {
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const { houses, categories } = useSettingsState();
   const { toast } = useToast();
+
+  const yearOptions = Array.from(new Set(items.map(i => i.yearPeriod).filter(Boolean)));
+  const artistOptions = Array.from(new Set(items.map(i => i.artist).filter(Boolean)));
 
   const handleEdit = (item: InventoryItem) => {
     localStorage.setItem('editingDraft', JSON.stringify(item));
@@ -97,13 +103,18 @@ const AllItems = () => {
     const matchesSearch = item.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          item.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
                          (item.artist && item.artist.toLowerCase().includes(searchTerm.toLowerCase()));
-    
+
     const matchesCategory = selectedCategory.length === 0 || selectedCategory.includes(item.category);
     const matchesSubcategory = selectedSubcategory.length === 0 || (item.subcategory && selectedSubcategory.includes(item.subcategory));
     const matchesHouse = selectedHouse.length === 0 || (item.house && selectedHouse.includes(item.house));
     const matchesRoom = selectedRoom.length === 0 || (item.room && selectedRoom.includes(`${item.house}|${item.room}`));
+    const matchesYear = selectedYear.length === 0 || (item.yearPeriod && selectedYear.includes(item.yearPeriod));
+    const matchesArtist = selectedArtist.length === 0 || (item.artist && selectedArtist.includes(item.artist));
+    const valuation = item.valuation ?? 0;
+    const matchesValuation = (valuationRange.min === undefined || valuation >= valuationRange.min) &&
+                             (valuationRange.max === undefined || valuation <= valuationRange.max);
 
-    return matchesSearch && matchesCategory && matchesSubcategory && matchesHouse && matchesRoom;
+    return matchesSearch && matchesCategory && matchesSubcategory && matchesHouse && matchesRoom && matchesYear && matchesArtist && matchesValuation;
   });
 
   // Sort filtered items
@@ -187,6 +198,14 @@ const AllItems = () => {
               setSelectedHouse={setSelectedHouse}
               selectedRoom={selectedRoom}
               setSelectedRoom={setSelectedRoom}
+              yearOptions={yearOptions}
+              selectedYear={selectedYear}
+              setSelectedYear={setSelectedYear}
+              artistOptions={artistOptions}
+              selectedArtist={selectedArtist}
+              setSelectedArtist={setSelectedArtist}
+              valuationRange={valuationRange}
+              setValuationRange={setValuationRange}
               viewMode={viewMode}
               setViewMode={setViewMode}
               onDownloadCSV={downloadCSV}

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -28,6 +28,9 @@ const CategoryPage = () => {
   const [selectedSubcategory, setSelectedSubcategory] = useState<string[]>([]);
   const [selectedHouse, setSelectedHouse] = useState<string[]>([]);
   const [selectedRoom, setSelectedRoom] = useState<string[]>([]); // stores "houseId|roomId"
+  const [selectedYear, setSelectedYear] = useState<string[]>([]);
+  const [selectedArtist, setSelectedArtist] = useState<string[]>([]);
+  const [valuationRange, setValuationRange] = useState<{ min?: number; max?: number }>({});
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const [items, setItems] = useState<InventoryItem[]>(sampleItems);
   const [selectedItem, setSelectedItem] = useState<InventoryItem | null>(null);
@@ -37,6 +40,8 @@ const CategoryPage = () => {
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const { categories, houses } = useSettingsState();
   const { toast } = useToast();
+  const yearOptions = Array.from(new Set(items.map(i => i.yearPeriod).filter(Boolean)));
+  const artistOptions = Array.from(new Set(items.map(i => i.artist).filter(Boolean)));
 
   const handleEdit = (item: InventoryItem) => {
     localStorage.setItem('editingDraft', JSON.stringify(item));
@@ -116,8 +121,13 @@ const CategoryPage = () => {
     const matchesSubcategory = selectedSubcategory.length === 0 || (item.subcategory && selectedSubcategory.includes(item.subcategory));
     const matchesHouse = selectedHouse.length === 0 || (item.house && selectedHouse.includes(item.house));
     const matchesRoom = selectedRoom.length === 0 || (item.room && selectedRoom.includes(`${item.house}|${item.room}`));
+    const matchesYear = selectedYear.length === 0 || (item.yearPeriod && selectedYear.includes(item.yearPeriod));
+    const matchesArtist = selectedArtist.length === 0 || (item.artist && selectedArtist.includes(item.artist));
+    const valuation = item.valuation ?? 0;
+    const matchesValuation = (valuationRange.min === undefined || valuation >= valuationRange.min) &&
+                             (valuationRange.max === undefined || valuation <= valuationRange.max);
 
-    return matchesSearch && matchesCategory && matchesSubcategory && matchesHouse && matchesRoom;
+    return matchesSearch && matchesCategory && matchesSubcategory && matchesHouse && matchesRoom && matchesYear && matchesArtist && matchesValuation;
   });
 
   const sortedItems = sortInventoryItems(
@@ -201,6 +211,14 @@ const CategoryPage = () => {
               setSelectedHouse={setSelectedHouse}
               selectedRoom={selectedRoom}
               setSelectedRoom={setSelectedRoom}
+              yearOptions={yearOptions}
+              selectedYear={selectedYear}
+              setSelectedYear={setSelectedYear}
+              artistOptions={artistOptions}
+              selectedArtist={selectedArtist}
+              setSelectedArtist={setSelectedArtist}
+              valuationRange={valuationRange}
+              setValuationRange={setValuationRange}
               viewMode={viewMode}
               setViewMode={setViewMode}
               onDownloadCSV={downloadCSV}

--- a/src/pages/HousePage.tsx
+++ b/src/pages/HousePage.tsx
@@ -28,6 +28,9 @@ const HousePage = () => {
   const [selectedSubcategory, setSelectedSubcategory] = useState<string[]>([]);
   const [selectedHouse, setSelectedHouse] = useState<string[]>(houseId ? [houseId] : []);
   const [selectedRoom, setSelectedRoom] = useState<string[]>([]); // stores "houseId|roomId"
+  const [selectedYear, setSelectedYear] = useState<string[]>([]);
+  const [selectedArtist, setSelectedArtist] = useState<string[]>([]);
+  const [valuationRange, setValuationRange] = useState<{ min?: number; max?: number }>({});
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const [items, setItems] = useState<InventoryItem[]>(sampleItems);
   const [selectedItem, setSelectedItem] = useState<InventoryItem | null>(null);
@@ -37,6 +40,8 @@ const HousePage = () => {
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const { houses, categories } = useSettingsState();
   const { toast } = useToast();
+  const yearOptions = Array.from(new Set(items.map(i => i.yearPeriod).filter(Boolean)));
+  const artistOptions = Array.from(new Set(items.map(i => i.artist).filter(Boolean)));
 
   const handleEdit = (item: InventoryItem) => {
     localStorage.setItem('editingDraft', JSON.stringify(item));
@@ -116,8 +121,13 @@ const HousePage = () => {
     const matchesSubcategory = selectedSubcategory.length === 0 || (item.subcategory && selectedSubcategory.includes(item.subcategory));
     const matchesHouse = item.house === houseId;
     const matchesRoom = selectedRoom.length === 0 || (item.room && selectedRoom.includes(`${item.house}|${item.room}`));
+    const matchesYear = selectedYear.length === 0 || (item.yearPeriod && selectedYear.includes(item.yearPeriod));
+    const matchesArtist = selectedArtist.length === 0 || (item.artist && selectedArtist.includes(item.artist));
+    const valuation = item.valuation ?? 0;
+    const matchesValuation = (valuationRange.min === undefined || valuation >= valuationRange.min) &&
+                             (valuationRange.max === undefined || valuation <= valuationRange.max);
 
-    return matchesSearch && matchesCategory && matchesSubcategory && matchesHouse && matchesRoom;
+    return matchesSearch && matchesCategory && matchesSubcategory && matchesHouse && matchesRoom && matchesYear && matchesArtist && matchesValuation;
   });
 
   const downloadCSV = () => {
@@ -200,6 +210,14 @@ const HousePage = () => {
               setSelectedHouse={setSelectedHouse}
               selectedRoom={selectedRoom}
               setSelectedRoom={setSelectedRoom}
+              yearOptions={yearOptions}
+              selectedYear={selectedYear}
+              setSelectedYear={setSelectedYear}
+              artistOptions={artistOptions}
+              selectedArtist={selectedArtist}
+              setSelectedArtist={setSelectedArtist}
+              valuationRange={valuationRange}
+              setValuationRange={setValuationRange}
               viewMode={viewMode}
               setViewMode={setViewMode}
               onDownloadCSV={downloadCSV}


### PR DESCRIPTION
## Summary
- improve select dropdown visibility
- align action buttons in history dialog
- make item condition optional
- add artist and valuation range filters
- connect new filters to pages and applied filter list
- ensure new filters occupy one-third width

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_686d6cacacf083259100d645933478fe