### PR TITLE
Remove item dropdown on category page

### DIFF
--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -10,7 +10,6 @@ import { ItemsTable } from "@/components/ItemsTable";
 import { ItemDetailDialog } from "@/components/ItemDetailDialog";
 import { ItemHistoryDialog } from "@/components/ItemHistoryDialog";
 import { EmptyState } from "@/components/EmptyState";
-import { MultiSelectFilter } from "@/components/MultiSelectFilter";
 import { sampleItems } from "@/data/sampleData";
 import { fetchInventory, deleteInventoryItem, restoreInventoryItem } from "@/lib/api";
 import { InventoryItem } from "@/types/inventory";
@@ -183,8 +182,6 @@ const CategoryPage = () => {
     URL.revokeObjectURL(url);
   };
 
-  const itemOptions = sortedItems.map(item => ({ id: item.id.toString(), name: item.title, image: item.image }));
-  const selectedItems = items.filter(item => selectedIds.includes(item.id.toString()));
 
   return (
     <SidebarProvider>
@@ -225,23 +222,16 @@ const CategoryPage = () => {
               permanentCategory={categoryId}
             />
 
-            <div className="max-w-md mb-6">
-              <MultiSelectFilter
-                placeholder="Select items"
-                options={itemOptions}
-                selectedValues={selectedIds}
-                onSelectionChange={setSelectedIds}
-              />
-            </div>
 
-            {selectedItems.length > 0 && (
-              <div className="mb-6 space-y-2">
-                <h3 className="font-medium text-slate-700">Selected Items</h3>
-                <ul className="list-disc pl-5 space-y-1">
-                  {selectedItems.map(item => (
-                    <li key={item.id}>{item.title}</li>
-                  ))}
-                </ul>
+            {selectedIds.length > 0 && (
+              <div className="mb-6 flex items-center justify-between bg-blue-100 border border-blue-200 text-blue-800 px-4 py-2 rounded">
+                <span className="text-sm font-medium">{selectedIds.length} item{selectedIds.length === 1 ? '' : 's'} selected</span>
+                <button
+                  className="text-sm underline"
+                  onClick={() => setSelectedIds([])}
+                >
+                  Clear
+                </button>
               </div>
             )}
 
@@ -254,9 +244,19 @@ const CategoryPage = () => {
             {sortedItems.length === 0 ? (
               <EmptyState />
             ) : viewMode === "grid" ? (
-              <ItemsGrid items={sortedItems} onItemClick={setSelectedItem} />
+              <ItemsGrid
+                items={sortedItems}
+                onItemClick={setSelectedItem}
+                selectedIds={selectedIds}
+                onSelectionChange={setSelectedIds}
+              />
             ) : viewMode === "list" ? (
-              <ItemsList items={sortedItems} onItemClick={setSelectedItem} />
+              <ItemsList
+                items={sortedItems}
+                onItemClick={setSelectedItem}
+                selectedIds={selectedIds}
+                onSelectionChange={setSelectedIds}
+              />
             ) : (
               <ItemsTable
                 items={sortedItems}
@@ -264,6 +264,8 @@ const CategoryPage = () => {
                 onSort={handleSort}
                 sortField={sortField}
                 sortDirection={sortDirection}
+                selectedIds={selectedIds}
+                onSelectionChange={setSelectedIds}
               />
             )}
 


### PR DESCRIPTION
## Summary
- remove MultiSelectFilter from `CategoryPage`
- show selected item count like other pages
- pass selection props to grid/list/table components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686d8dfff20883259a8298447fdb369a