### PR TITLE
Add API key support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # Base URL for your FastAPI server
 VITE_API_URL=http://localhost:8000
+# API key for your FastAPI server (optional)
+VITE_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+# Environment files
+.env

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The app will be available at `http://localhost:5173` by default.
 
 ## Connecting a FastAPI backend
 
-1. Create a `.env` file based on `.env.example` and set `VITE_API_URL` to the URL of your FastAPI server.
+1. Create a `.env` file based on `.env.example` and set `VITE_API_URL` to the URL of your FastAPI server. If your API requires authentication, also set `VITE_API_KEY` with your key value.
 2. Start your FastAPI app (for example `uvicorn your_package.main:app --reload`).
 3. The frontend will attempt to fetch inventory data from `${VITE_API_URL}/items`.
 4. If the request fails, the app falls back to sample data.
@@ -105,7 +105,7 @@ to that service and the app will use it for data.
 
 ## Running with Docker
 
-1. Create a `.env` file based on `.env.example` and adjust `VITE_API_URL` if needed.
+1. Create a `.env` file based on `.env.example` and adjust `VITE_API_URL` and `VITE_API_KEY` if needed.
 2. Build the image and start the container:
 
 ```bash

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,12 @@
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+const API_KEY = import.meta.env.VITE_API_KEY;
+
+function buildHeaders(contentType?: string) {
+  const headers: Record<string, string> = {};
+  if (contentType) headers['Content-Type'] = contentType;
+  if (API_KEY) headers['X-API-Key'] = API_KEY;
+  return headers;
+}
 
 import { InventoryItem } from '@/types/inventory';
 import { sampleItems } from '@/data/sampleData';
@@ -26,7 +34,9 @@ function saveLocalInventory(items: InventoryItem[]) {
 
 export async function fetchInventory(): Promise<InventoryItem[]> {
   try {
-    const response = await fetch(`${API_URL}/items`);
+    const response = await fetch(`${API_URL}/items`, {
+      headers: buildHeaders(),
+    });
     if (!response.ok) throw new Error('Failed to fetch items');
     const data = await response.json();
     saveLocalInventory(data);
@@ -40,7 +50,7 @@ export async function createInventoryItem(item: InventoryItem) {
   try {
     const response = await fetch(`${API_URL}/items`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: buildHeaders('application/json'),
       body: JSON.stringify(item)
     });
     if (!response.ok) throw new Error('Failed to create item');
@@ -62,7 +72,7 @@ export async function updateInventoryItem(id: number | string, updates: Inventor
   try {
     const response = await fetch(`${API_URL}/items/${id}`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
+      headers: buildHeaders('application/json'),
       body: JSON.stringify(updates)
     });
     if (!response.ok) throw new Error('Failed to update item');
@@ -94,6 +104,7 @@ export async function deleteInventoryItem(id: number | string) {
   try {
     const response = await fetch(`${API_URL}/items/${id}`, {
       method: 'DELETE',
+      headers: buildHeaders(),
     });
     if (!response.ok) throw new Error('Failed to delete item');
     const items = getAllInventory().map(item => item.id === Number(id) ? { ...item, deleted: true } : item);


### PR DESCRIPTION
## Summary
- allow sending `X-API-Key` header on API requests
- document `VITE_API_KEY` usage in the README
- update `.env.example` with `VITE_API_KEY`
- ignore `.env` by default

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_686d91804a208325912def9a7efde25e