### PR TITLE
Add optional hot reload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,29 @@
-# Stage 1: Build the application
-FROM node:20-alpine AS builder
+# Base stage with dependencies
+FROM node:20-alpine AS base
 WORKDIR /app
 
 # Install dependencies
 COPY package.json package-lock.json bun.lockb* ./
 RUN npm ci
 
-# Copy source code
+# Stage 1: Build the application
+FROM base AS builder
 COPY . .
-
-# Build the production files
 ARG VITE_API_URL=http://localhost:8000
 ENV VITE_API_URL=$VITE_API_URL
 RUN npm run build
 
-# Stage 2: Serve the built app with nginx
+# Stage 2: Development server (optional)
+# Use this stage when you need hot reloading inside Docker.
+# The docker-compose file contains commented instructions to enable it.
+FROM base AS dev
+COPY . .
+ARG VITE_API_URL=http://localhost:8000
+ENV VITE_API_URL=$VITE_API_URL
+EXPOSE 8080
+CMD ["npm", "run", "dev", "--", "--host"]
+
+# Stage 3: Serve the built app with nginx
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
 EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,14 @@ services:
         - VITE_API_URL=${VITE_API_URL:-http://localhost:8000}
     ports:
       - "3000:80"
+      # - "3000:8080"  # use this when enabling the dev target
     env_file:
       - .env
+    # To automatically reload on code changes during development,
+    # uncomment the line below and the port mapping above. This mounts
+    # your source so Vite can watch for updates.
+    # volumes:
+    #   - .:/app
+    #   - /app/node_modules
+    # and build using the 'dev' target:
+    # docker compose build --target dev frontend


### PR DESCRIPTION
## Summary
- add a dev stage in Dockerfile to run Vite with hot reload
- document optional bind mount and dev build target in docker-compose

## Testing
- `npm ci`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686ed1e5754883259aa8ee55aed83b61