### PR TITLE
Add dark mode toggle and highlight active sidebar links

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -54,7 +54,7 @@ export function AppSidebar() {
     icon: getIconComponent(house.icon)
   }));
 
-  const isActive = (path: string) => {
+  const checkActive = (path: string) => {
     if (path === "/") {
       return currentPath === "/";
     }
@@ -62,19 +62,19 @@ export function AppSidebar() {
   };
 
   const getNavCls = ({ isActive: active }: { isActive: boolean }) =>
-    active 
-      ? "bg-blue-100 text-blue-900 font-medium border-r-2 border-blue-600" 
-      : "hover:bg-slate-100 text-slate-700";
+    active
+      ? "bg-blue-100 dark:bg-blue-900 text-blue-900 dark:text-blue-100 font-medium border-r-2 border-blue-600 dark:border-blue-400"
+      : "hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-700 dark:text-slate-300";
 
   return (
     <Sidebar className={isCollapsed ? "w-14" : "w-64"} collapsible="icon">
-      <SidebarContent className="bg-white border-r border-slate-200">
+      <SidebarContent className="bg-white border-r border-slate-200 dark:bg-slate-900 dark:border-slate-700">
         {/* Logo Section */}
-        <div className="p-6 border-b border-slate-200">
+        <div className="p-6 border-b border-slate-200 dark:border-slate-700">
           {!isCollapsed ? (
             <div>
-              <h2 className="text-xl font-bold text-slate-900">Murgenere</h2>
-              <p className="text-sm text-slate-600">Collection Manager</p>
+              <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">Murgenere</h2>
+              <p className="text-sm text-slate-600 dark:text-slate-400">Collection Manager</p>
             </div>
           ) : (
             <div className="text-center">
@@ -87,7 +87,7 @@ export function AppSidebar() {
 
         {/* Main Navigation */}
         <SidebarGroup>
-          <SidebarGroupLabel className="text-slate-500 uppercase tracking-wider text-xs font-semibold">
+          <SidebarGroupLabel className="text-slate-500 dark:text-slate-400 uppercase tracking-wider text-xs font-semibold">
             {!isCollapsed && "Main Menu"}
           </SidebarGroupLabel>
           <SidebarGroupContent>
@@ -95,10 +95,12 @@ export function AppSidebar() {
               {mainItems.map((item) => (
                 <SidebarMenuItem key={item.title}>
                   <SidebarMenuButton asChild>
-                    <NavLink 
-                      to={item.url} 
+                    <NavLink
+                      to={item.url}
                       end={item.url === "/"}
-                      className={({ isActive }) => getNavCls({ isActive })}
+                      className={({ isActive }) =>
+                        getNavCls({ isActive: isActive || checkActive(item.url) })
+                      }
                     >
                       <item.icon className="w-4 h-4" />
                       {!isCollapsed && <span>{item.title}</span>}
@@ -112,7 +114,7 @@ export function AppSidebar() {
 
         {/* Categories */}
         <SidebarGroup>
-          <SidebarGroupLabel className="text-slate-500 uppercase tracking-wider text-xs font-semibold">
+          <SidebarGroupLabel className="text-slate-500 dark:text-slate-400 uppercase tracking-wider text-xs font-semibold">
             {!isCollapsed && "Categories"}
           </SidebarGroupLabel>
           <SidebarGroupContent>
@@ -120,9 +122,11 @@ export function AppSidebar() {
               {categoryItems.map((item) => (
                 <SidebarMenuItem key={item.title}>
                   <SidebarMenuButton asChild>
-                    <NavLink 
+                    <NavLink
                       to={item.url}
-                      className={({ isActive }) => getNavCls({ isActive })}
+                      className={({ isActive }) =>
+                        getNavCls({ isActive: isActive || checkActive(item.url) })
+                      }
                     >
                       <item.icon className="w-4 h-4" />
                       {!isCollapsed && <span>{item.title}</span>}
@@ -136,7 +140,7 @@ export function AppSidebar() {
 
         {/* Houses */}
         <SidebarGroup>
-          <SidebarGroupLabel className="text-slate-500 uppercase tracking-wider text-xs font-semibold">
+          <SidebarGroupLabel className="text-slate-500 dark:text-slate-400 uppercase tracking-wider text-xs font-semibold">
             {!isCollapsed && "Houses"}
           </SidebarGroupLabel>
           <SidebarGroupContent>
@@ -144,9 +148,11 @@ export function AppSidebar() {
               {houseItems.map((item) => (
                 <SidebarMenuItem key={item.title}>
                   <SidebarMenuButton asChild>
-                    <NavLink 
+                    <NavLink
                       to={item.url}
-                      className={({ isActive }) => getNavCls({ isActive })}
+                      className={({ isActive }) =>
+                        getNavCls({ isActive: isActive || checkActive(item.url) })
+                      }
                     >
                       <item.icon className="w-4 h-4" />
                       {!isCollapsed && <span>{item.title}</span>}
@@ -159,15 +165,17 @@ export function AppSidebar() {
         </SidebarGroup>
 
         {/* Settings at bottom */}
-        <div className="mt-auto border-t border-slate-200">
+        <div className="mt-auto border-t border-slate-200 dark:border-slate-700">
           <SidebarGroup>
             <SidebarGroupContent>
               <SidebarMenu>
                 <SidebarMenuItem>
                   <SidebarMenuButton asChild>
-                    <NavLink 
+                    <NavLink
                       to="/settings"
-                      className={({ isActive }) => getNavCls({ isActive })}
+                      className={({ isActive }) =>
+                        getNavCls({ isActive: isActive || checkActive('/settings') })
+                      }
                     >
                       <Settings className="w-4 h-4" />
                       {!isCollapsed && <span>Settings</span>}

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -1,0 +1,18 @@
+import { useTheme } from 'next-themes';
+import { Moon, Sun } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export function DarkModeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
+
+  const toggleTheme = () => {
+    setTheme(isDark ? 'light' : 'dark');
+  };
+
+  return (
+    <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label="Toggle theme">
+      {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+    </Button>
+  );
+}

--- a/src/components/InventoryHeader.tsx
+++ b/src/components/InventoryHeader.tsx
@@ -1,6 +1,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Plus, Download } from "lucide-react";
+import { DarkModeToggle } from "@/components/DarkModeToggle";
 import { useNavigate } from "react-router-dom";
 import { useLocation } from "react-router-dom";
 import { sampleItems } from "@/data/sampleData";
@@ -92,13 +93,15 @@ export function InventoryHeader() {
               </Button>
             </>
           )}
-          
+
           {location.pathname !== '/add' && (
             <Button onClick={() => navigate('/add')}>
               <Plus className="w-4 h-4 mr-2" />
               Add Item
             </Button>
           )}
+
+          <DarkModeToggle />
         </div>
       </div>
     </header>

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,15 @@
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ThemeProviderProps } from "next-themes/dist/types";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { ThemeProvider } from './components/ThemeProvider'
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>
+);

--- a/src/pages/AddItem.tsx
+++ b/src/pages/AddItem.tsx
@@ -11,7 +11,7 @@ const AddItem = () => {
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         
         <div className="flex-1 flex flex-col">

--- a/src/pages/AllItems.tsx
+++ b/src/pages/AllItems.tsx
@@ -175,7 +175,7 @@ const AllItems = () => {
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         
         <div className="flex-1 flex flex-col">

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -76,7 +76,7 @@ const Analytics = () => {
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         
         <div className="flex-1 flex flex-col">

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -185,7 +185,7 @@ const CategoryPage = () => {
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
 
         <div className="flex-1 flex flex-col">

--- a/src/pages/Drafts.tsx
+++ b/src/pages/Drafts.tsx
@@ -52,7 +52,7 @@ const Drafts = () => {
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         
         <div className="flex-1 flex flex-col">

--- a/src/pages/HousePage.tsx
+++ b/src/pages/HousePage.tsx
@@ -187,7 +187,7 @@ const HousePage = () => {
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         
         <div className="flex-1 flex flex-col">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -20,7 +20,7 @@ const Index = () => {
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         
         <div className="flex-1 flex flex-col">

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -32,7 +32,7 @@ const Login = () => {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
           <div className="mx-auto w-12 h-12 bg-blue-600 rounded-lg flex items-center justify-center mb-4">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -7,7 +7,7 @@ import { SettingsManagement } from "@/components/SettingsManagement";
 const Settings = () => {
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         
         <div className="flex-1 flex flex-col">


### PR DESCRIPTION
## Summary
- add a ThemeProvider based on next-themes
- create a DarkModeToggle component
- wrap the app in ThemeProvider
- show a toggle button in the inventory header
- support dark mode colors for sidebar and highlight active navigation
- replace page background colors with `bg-background`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ed3cab8348325ba082c7f0ecd4f97