### PR TITLE
Add dark mode styling fixes

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -54,27 +54,23 @@ export function AppSidebar() {
     icon: getIconComponent(house.icon)
   }));
 
-  const isActive = (path: string) => {
+  const checkActive = (path: string) => {
     if (path === "/") {
       return currentPath === "/";
     }
     return currentPath.startsWith(path);
   };
 
-  const getNavCls = ({ isActive: active }: { isActive: boolean }) =>
-    active 
-      ? "bg-blue-100 text-blue-900 font-medium border-r-2 border-blue-600" 
-      : "hover:bg-slate-100 text-slate-700";
 
   return (
     <Sidebar className={isCollapsed ? "w-14" : "w-64"} collapsible="icon">
-      <SidebarContent className="bg-white border-r border-slate-200">
+      <SidebarContent className="border-r border-sidebar-border">
         {/* Logo Section */}
-        <div className="p-6 border-b border-slate-200">
+        <div className="p-6 border-b border-slate-200 dark:border-slate-700">
           {!isCollapsed ? (
             <div>
-              <h2 className="text-xl font-bold text-slate-900">Murgenere</h2>
-              <p className="text-sm text-slate-600">Collection Manager</p>
+              <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">Murgenere</h2>
+              <p className="text-sm text-slate-600 dark:text-slate-400">Collection Manager</p>
             </div>
           ) : (
             <div className="text-center">
@@ -87,18 +83,18 @@ export function AppSidebar() {
 
         {/* Main Navigation */}
         <SidebarGroup>
-          <SidebarGroupLabel className="text-slate-500 uppercase tracking-wider text-xs font-semibold">
+          <SidebarGroupLabel className="text-slate-500 dark:text-slate-400 uppercase tracking-wider text-xs font-semibold">
             {!isCollapsed && "Main Menu"}
           </SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               {mainItems.map((item) => (
                 <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild>
-                    <NavLink 
-                      to={item.url} 
+                  <SidebarMenuButton asChild isActive={checkActive(item.url)}>
+                    <NavLink
+                      to={item.url}
                       end={item.url === "/"}
-                      className={({ isActive }) => getNavCls({ isActive })}
+                      className="flex items-center gap-2 w-full"
                     >
                       <item.icon className="w-4 h-4" />
                       {!isCollapsed && <span>{item.title}</span>}
@@ -112,18 +108,15 @@ export function AppSidebar() {
 
         {/* Categories */}
         <SidebarGroup>
-          <SidebarGroupLabel className="text-slate-500 uppercase tracking-wider text-xs font-semibold">
+          <SidebarGroupLabel className="text-slate-500 dark:text-slate-400 uppercase tracking-wider text-xs font-semibold">
             {!isCollapsed && "Categories"}
           </SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               {categoryItems.map((item) => (
                 <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild>
-                    <NavLink 
-                      to={item.url}
-                      className={({ isActive }) => getNavCls({ isActive })}
-                    >
+                  <SidebarMenuButton asChild isActive={checkActive(item.url)}>
+                    <NavLink to={item.url} className="flex items-center gap-2 w-full">
                       <item.icon className="w-4 h-4" />
                       {!isCollapsed && <span>{item.title}</span>}
                     </NavLink>
@@ -136,18 +129,15 @@ export function AppSidebar() {
 
         {/* Houses */}
         <SidebarGroup>
-          <SidebarGroupLabel className="text-slate-500 uppercase tracking-wider text-xs font-semibold">
+          <SidebarGroupLabel className="text-slate-500 dark:text-slate-400 uppercase tracking-wider text-xs font-semibold">
             {!isCollapsed && "Houses"}
           </SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               {houseItems.map((item) => (
                 <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild>
-                    <NavLink 
-                      to={item.url}
-                      className={({ isActive }) => getNavCls({ isActive })}
-                    >
+                  <SidebarMenuButton asChild isActive={checkActive(item.url)}>
+                    <NavLink to={item.url} className="flex items-center gap-2 w-full">
                       <item.icon className="w-4 h-4" />
                       {!isCollapsed && <span>{item.title}</span>}
                     </NavLink>
@@ -159,16 +149,13 @@ export function AppSidebar() {
         </SidebarGroup>
 
         {/* Settings at bottom */}
-        <div className="mt-auto border-t border-slate-200">
+        <div className="mt-auto border-t border-slate-200 dark:border-slate-700">
           <SidebarGroup>
             <SidebarGroupContent>
               <SidebarMenu>
                 <SidebarMenuItem>
-                  <SidebarMenuButton asChild>
-                    <NavLink 
-                      to="/settings"
-                      className={({ isActive }) => getNavCls({ isActive })}
-                    >
+                  <SidebarMenuButton asChild isActive={checkActive('/settings')}>
+                    <NavLink to="/settings" className="flex items-center gap-2 w-full">
                       <Settings className="w-4 h-4" />
                       {!isCollapsed && <span>Settings</span>}
                     </NavLink>

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -1,0 +1,18 @@
+import { useTheme } from 'next-themes';
+import { Moon, Sun } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export function DarkModeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
+
+  const toggleTheme = () => {
+    setTheme(isDark ? 'light' : 'dark');
+  };
+
+  return (
+    <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label="Toggle theme">
+      {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+    </Button>
+  );
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -47,8 +47,8 @@ export function Dashboard({ items }: DashboardProps) {
           <CardContent className="p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-slate-600">Total Items</p>
-                <p className="text-2xl font-bold text-slate-900">{totalItems}</p>
+                <p className="text-sm text-slate-600 dark:text-slate-400">Total Items</p>
+                <p className="text-2xl font-bold text-slate-900 dark:text-slate-100">{totalItems}</p>
               </div>
               <Package className="w-8 h-8 text-blue-600" />
             </div>
@@ -59,8 +59,8 @@ export function Dashboard({ items }: DashboardProps) {
           <CardContent className="p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-slate-600">Total Valuation</p>
-                <p className="text-2xl font-bold text-slate-900">
+                <p className="text-sm text-slate-600 dark:text-slate-400">Total Valuation</p>
+                <p className="text-2xl font-bold text-slate-900 dark:text-slate-100">
                   ${totalValuation.toLocaleString()}
                 </p>
               </div>
@@ -75,8 +75,8 @@ export function Dashboard({ items }: DashboardProps) {
           <CardContent className="p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-slate-600">Categories</p>
-                <p className="text-2xl font-bold text-slate-900">{categories.length}</p>
+                <p className="text-sm text-slate-600 dark:text-slate-400">Categories</p>
+                <p className="text-2xl font-bold text-slate-900 dark:text-slate-100">{categories.length}</p>
               </div>
               <div className="w-8 h-8 rounded-full bg-purple-100 flex items-center justify-center">
                 <span className="text-purple-600 font-bold">#</span>
@@ -88,7 +88,7 @@ export function Dashboard({ items }: DashboardProps) {
 
       {/* Categories */}
       <div>
-        <h2 className="text-xl font-semibold text-slate-900 mb-4">Browse by Category</h2>
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-4">Browse by Category</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {categoryStats.map((category) => (
             <Link
@@ -101,8 +101,8 @@ export function Dashboard({ items }: DashboardProps) {
                     <div className="flex items-center gap-3">
                       {getCategoryIcon(category.id)}
                       <div>
-                        <h3 className="font-semibold text-slate-900">{category.name}</h3>
-                        <p className="text-sm text-slate-600">{category.count} items</p>
+                        <h3 className="font-semibold text-slate-900 dark:text-slate-100">{category.name}</h3>
+                        <p className="text-sm text-slate-600 dark:text-slate-400">{category.count} items</p>
                       </div>
                     </div>
                     <Badge variant="secondary">{category.count}</Badge>
@@ -116,7 +116,7 @@ export function Dashboard({ items }: DashboardProps) {
 
       {/* Houses */}
       <div>
-        <h2 className="text-xl font-semibold text-slate-900 mb-4">Browse by Location</h2>
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mb-4">Browse by Location</h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {houseStats.map((house) => (
             <Link
@@ -129,8 +129,8 @@ export function Dashboard({ items }: DashboardProps) {
                     <div className="flex items-center gap-3">
                       <Home className="w-8 h-8 text-indigo-600" />
                       <div>
-                        <h3 className="font-semibold text-slate-900">{house.name}</h3>
-                        <p className="text-sm text-slate-600">{house.count} items</p>
+                        <h3 className="font-semibold text-slate-900 dark:text-slate-100">{house.name}</h3>
+                        <p className="text-sm text-slate-600 dark:text-slate-400">{house.count} items</p>
                       </div>
                     </div>
                     <Badge variant="secondary">{house.count}</Badge>

--- a/src/components/InventoryHeader.tsx
+++ b/src/components/InventoryHeader.tsx
@@ -1,6 +1,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Plus, Download } from "lucide-react";
+import { DarkModeToggle } from "@/components/DarkModeToggle";
 import { useNavigate } from "react-router-dom";
 import { useLocation } from "react-router-dom";
 import { sampleItems } from "@/data/sampleData";
@@ -67,10 +68,10 @@ export function InventoryHeader() {
   };
 
   return (
-    <header className="border-b bg-white px-6 py-4">
+    <header className="border-b border-border bg-card px-6 py-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
-          <h1 className="text-2xl font-bold text-slate-900">
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
             Collection Manager
           </h1>
         </div>
@@ -92,13 +93,15 @@ export function InventoryHeader() {
               </Button>
             </>
           )}
-          
+
           {location.pathname !== '/add' && (
             <Button onClick={() => navigate('/add')}>
               <Plus className="w-4 h-4 mr-2" />
               Add Item
             </Button>
           )}
+
+          <DarkModeToggle />
         </div>
       </div>
     </header>

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -38,7 +38,7 @@ export function ItemCard({ item, onClick, selected, onSelect }: ItemCardProps) {
           <Checkbox
             checked={selected}
             onClick={handleCheckbox}
-            className="absolute top-2 left-2 z-10 bg-white rounded-sm"
+            className="absolute top-2 left-2 z-10 bg-card rounded-sm"
           />
         )}
         <div className="aspect-square overflow-hidden rounded-t-lg">
@@ -50,26 +50,26 @@ export function ItemCard({ item, onClick, selected, onSelect }: ItemCardProps) {
         </div>
         <div className="p-4">
           <div className="flex items-start justify-between mb-2">
-            <h3 className="font-semibold text-slate-900 line-clamp-2">{item.title}</h3>
+            <h3 className="font-semibold text-slate-900 dark:text-slate-100 line-clamp-2">{item.title}</h3>
           </div>
           
           {item.artist && (
-            <p className="text-slate-600 text-sm font-medium mb-1">by {item.artist}</p>
+            <p className="text-slate-600 dark:text-slate-400 text-sm font-medium mb-1">by {item.artist}</p>
           )}
           
           {item.yearPeriod && (
-            <p className="text-slate-600 text-sm mb-2">{item.yearPeriod}</p>
+            <p className="text-slate-600 dark:text-slate-400 text-sm mb-2">{item.yearPeriod}</p>
           )}
           
           <div className="flex items-center justify-between text-sm">
-            <div className="flex gap-2 text-xs text-slate-500">
+            <div className="flex gap-2 text-xs text-slate-500 dark:text-slate-400">
               <span className="capitalize">{item.category}</span>
               {item.subcategory && <span>• {item.subcategory}</span>}
             </div>
           </div>
           
           {(item.house || item.room) && (
-            <div className="mt-2 text-xs text-slate-500">
+            <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">
               {item.house && <span className="capitalize">{item.house.replace('-', ' ')}</span>}
               {item.house && item.room && <span> • </span>}
               {item.room && <span className="capitalize">{item.room.replace('-', ' ')}</span>}

--- a/src/components/ItemsList.tsx
+++ b/src/components/ItemsList.tsx
@@ -110,8 +110,8 @@ export function ItemsList({ items, onItemClick, selectedIds = [], onSelectionCha
   return (
     <div className="space-y-4">
       {/* Sort Controls */}
-      <div className="flex flex-wrap gap-2 p-4 bg-white border rounded-lg">
-        <span className="text-sm text-slate-600 mr-2">Sort by:</span>
+      <div className="flex flex-wrap gap-2 p-4 bg-card border border-border rounded-lg">
+        <span className="text-sm text-slate-600 dark:text-slate-400 mr-2">Sort by:</span>
         <SortButton field="title">Title</SortButton>
         <SortButton field="artist">Artist</SortButton>
         <SortButton field="category">Category</SortButton>
@@ -147,7 +147,7 @@ export function ItemsList({ items, onItemClick, selectedIds = [], onSelectionCha
                       e.stopPropagation();
                       toggle(item.id.toString(), idx, false);
                     }}
-                    className="absolute -left-3 top-1 bg-white rounded-sm"
+                    className="absolute -left-3 top-1 bg-card rounded-sm"
                   />
                 )}
                 <img
@@ -159,9 +159,9 @@ export function ItemsList({ items, onItemClick, selectedIds = [], onSelectionCha
               <div className="flex-1 space-y-2">
                 <div className="flex items-start justify-between">
                   <div>
-                    <h3 className="text-lg font-semibold text-slate-900">{item.title}</h3>
+                    <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{item.title}</h3>
                     {item.artist && (
-                      <p className="text-slate-600 text-sm font-medium">by {item.artist}</p>
+                      <p className="text-slate-600 dark:text-slate-400 text-sm font-medium">by {item.artist}</p>
                     )}
                   </div>
                   <div className="flex gap-2">
@@ -178,62 +178,62 @@ export function ItemsList({ items, onItemClick, selectedIds = [], onSelectionCha
                 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
                   <div>
-                    <span className="font-medium text-slate-600">Category:</span>
+                    <span className="font-medium text-slate-600 dark:text-slate-400">Category:</span>
                     <span className="ml-2 capitalize">{item.category}</span>
                     {item.subcategory && (
-                      <span className="text-slate-500"> • {item.subcategory}</span>
+                      <span className="text-slate-500 dark:text-slate-400"> • {item.subcategory}</span>
                     )}
                   </div>
                   
                   {(item.house || item.room) && (
                     <div>
-                      <span className="font-medium text-slate-600">Location:</span>
+                      <span className="font-medium text-slate-600 dark:text-slate-400">Location:</span>
                       {item.house && <span className="ml-2 capitalize">{item.house.replace('-', ' ')}</span>}
-                      {item.house && item.room && <span className="text-slate-500"> • </span>}
+                      {item.house && item.room && <span className="text-slate-500 dark:text-slate-400"> • </span>}
                       {item.room && <span className="capitalize">{item.room.replace('-', ' ')}</span>}
                     </div>
                   )}
                   
                   {item.yearPeriod && (
                     <div>
-                      <span className="font-medium text-slate-600">Period:</span>
+                      <span className="font-medium text-slate-600 dark:text-slate-400">Period:</span>
                       <span className="ml-2">{item.yearPeriod}</span>
                     </div>
                   )}
                   
                   {item.size && (
                     <div>
-                      <span className="font-medium text-slate-600">Size:</span>
+                      <span className="font-medium text-slate-600 dark:text-slate-400">Size:</span>
                       <span className="ml-2">{item.size}</span>
                     </div>
                   )}
                   
                   {item.quantity && item.quantity > 1 && (
                     <div>
-                      <span className="font-medium text-slate-600">Quantity:</span>
+                      <span className="font-medium text-slate-600 dark:text-slate-400">Quantity:</span>
                       <span className="ml-2">{item.quantity}</span>
                     </div>
                   )}
                   
                   {item.valuationDate && (
                     <div>
-                      <span className="font-medium text-slate-600">Valued:</span>
+                      <span className="font-medium text-slate-600 dark:text-slate-400">Valued:</span>
                       <span className="ml-2">{item.valuationDate}</span>
                       {item.valuationPerson && (
-                        <span className="text-slate-500"> by {item.valuationPerson}</span>
+                        <span className="text-slate-500 dark:text-slate-400"> by {item.valuationPerson}</span>
                       )}
                     </div>
                   )}
                 </div>
                 
                 {item.description && (
-                  <p className="text-slate-600 text-sm line-clamp-2">{item.description}</p>
+                  <p className="text-slate-600 dark:text-slate-400 text-sm line-clamp-2">{item.description}</p>
                 )}
                 
                 {item.notes && (
                   <div className="pt-2 border-t">
-                    <span className="font-medium text-slate-600 text-sm">Notes:</span>
-                    <p className="text-slate-500 text-sm mt-1">{item.notes}</p>
+                    <span className="font-medium text-slate-600 dark:text-slate-400 text-sm">Notes:</span>
+                    <p className="text-slate-500 dark:text-slate-400 text-sm mt-1">{item.notes}</p>
                   </div>
                 )}
               </div>

--- a/src/components/ItemsTable.tsx
+++ b/src/components/ItemsTable.tsx
@@ -133,7 +133,7 @@ export function ItemsTable({ items, onItemClick, onSort, sortField, sortDirectio
                         e.stopPropagation();
                         toggle(item.id.toString(), idx, false);
                       }}
-                      className="bg-white rounded-sm"
+                      className="bg-card rounded-sm"
                     />
                   )}
                   <div className="w-12 h-12 rounded overflow-hidden">

--- a/src/components/SearchFilters.tsx
+++ b/src/components/SearchFilters.tsx
@@ -83,7 +83,7 @@ export function SearchFilters({
       {/* Search and filters in aligned grid */}
       <div
         className={cn(
-          "bg-white p-4 rounded-lg border shadow-sm relative",
+          "bg-card p-4 rounded-lg border shadow-sm relative",
           activeCount > 0 && "border-primary"
         )}
       >

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,15 @@
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ThemeProviderProps } from "next-themes/dist/types";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -98,9 +98,9 @@ export function AppliedFilters({
   if (!hasActiveFilters) return null;
 
   return (
-    <div className="bg-white p-4 rounded-lg border shadow-sm">
+    <div className="bg-card p-4 rounded-lg border shadow-sm">
       <div className="flex items-center justify-between mb-3">
-        <h4 className="text-sm font-medium text-slate-700">Applied Filters</h4>
+        <h4 className="text-sm font-medium text-slate-700 dark:text-slate-300">Applied Filters</h4>
         <Button variant="ghost" size="sm" onClick={clearAllFilters}>
           Clear All
         </Button>

--- a/src/components/filters/FilterHeader.tsx
+++ b/src/components/filters/FilterHeader.tsx
@@ -15,8 +15,8 @@ export function FilterHeader({
   onDownloadCSV,
 }: FilterHeaderProps) {
   return (
-    <div className="flex items-center justify-between bg-white p-4 rounded-lg border shadow-sm">
-      <h3 className="text-lg font-semibold text-slate-900">Filter & View Options</h3>
+    <div className="flex items-center justify-between bg-card p-4 rounded-lg border shadow-sm">
+      <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Filter & View Options</h3>
       <div className="flex items-center gap-2">
         {onDownloadCSV && (
           <Button variant="outline" size="sm" onClick={onDownloadCSV}>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { ThemeProvider } from './components/ThemeProvider'
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>
+);

--- a/src/pages/AddItem.tsx
+++ b/src/pages/AddItem.tsx
@@ -11,7 +11,7 @@ const AddItem = () => {
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         
         <div className="flex-1 flex flex-col">

--- a/src/pages/AllItems.tsx
+++ b/src/pages/AllItems.tsx
@@ -175,7 +175,7 @@ const AllItems = () => {
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         
         <div className="flex-1 flex flex-col">

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -76,7 +76,7 @@ const Analytics = () => {
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         
         <div className="flex-1 flex flex-col">

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -185,7 +185,7 @@ const CategoryPage = () => {
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
 
         <div className="flex-1 flex flex-col">

--- a/src/pages/Drafts.tsx
+++ b/src/pages/Drafts.tsx
@@ -52,7 +52,7 @@ const Drafts = () => {
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         
         <div className="flex-1 flex flex-col">

--- a/src/pages/HousePage.tsx
+++ b/src/pages/HousePage.tsx
@@ -187,7 +187,7 @@ const HousePage = () => {
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         
         <div className="flex-1 flex flex-col">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -20,7 +20,7 @@ const Index = () => {
 
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         
         <div className="flex-1 flex flex-col">

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -32,7 +32,7 @@ const Login = () => {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
           <div className="mx-auto w-12 h-12 bg-blue-600 rounded-lg flex items-center justify-center mb-4">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -7,7 +7,7 @@ import { SettingsManagement } from "@/components/SettingsManagement";
 const Settings = () => {
   return (
     <SidebarProvider>
-      <div className="min-h-screen flex w-full bg-slate-50">
+      <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
         
         <div className="flex-1 flex flex-col">


### PR DESCRIPTION
## Summary
- make sidebar content use theme colors and rely on SidebarMenuButton `isActive`
- switch headers and cards to theme-aware colors
- update item listings and dashboard text for dark theme
- ensure checkboxes and filter sections use `bg-card`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ed3cab8348325ba082c7f0ecd4f97