### PR TITLE
Fix dark mode colors

### DIFF
--- a/src/components/HierarchicalCategorySelector.tsx
+++ b/src/components/HierarchicalCategorySelector.tsx
@@ -43,7 +43,7 @@ export function HierarchicalCategorySelector({
         <SelectContent>
           {categories.map((category) => (
             <div key={category.id}>
-              <div className="px-2 py-1 text-sm font-medium text-slate-600 bg-slate-50">
+              <div className="px-2 py-1 text-sm font-medium text-slate-600 bg-muted">
                 {category.name}
               </div>
               <SelectItem 

--- a/src/components/HierarchicalHouseRoomSelector.tsx
+++ b/src/components/HierarchicalHouseRoomSelector.tsx
@@ -42,7 +42,7 @@ export function HierarchicalHouseRoomSelector({
         <SelectContent>
           {houses.map((house) => (
             <div key={house.id}>
-              <div className="px-2 py-1 text-sm font-medium text-slate-600 bg-slate-50">
+              <div className="px-2 py-1 text-sm font-medium text-slate-600 bg-muted">
                 {house.name}
               </div>
               {house.rooms.map((room) => (

--- a/src/components/InventoryHeader.tsx
+++ b/src/components/InventoryHeader.tsx
@@ -69,7 +69,7 @@ export function InventoryHeader() {
   };
 
   return (
-    <header className="border-b bg-white px-6 py-4">
+    <header className="border-b bg-card px-6 py-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
           <h1 className="text-2xl font-bold text-slate-900">

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -38,7 +38,7 @@ export function ItemCard({ item, onClick, selected, onSelect }: ItemCardProps) {
           <Checkbox
             checked={selected}
             onClick={handleCheckbox}
-            className="absolute top-2 left-2 z-10 bg-white rounded-sm"
+            className="absolute top-2 left-2 z-10 bg-card rounded-sm"
           />
         )}
         <div className="aspect-square overflow-hidden rounded-t-lg">

--- a/src/components/ItemsList.tsx
+++ b/src/components/ItemsList.tsx
@@ -95,7 +95,7 @@ export function ItemsList({ items, onItemClick, selectedIds = [], onSelectionCha
   return (
     <div className="space-y-4">
       {/* Sort Controls */}
-      <div className="flex flex-wrap gap-2 p-4 bg-white border rounded-lg">
+      <div className="flex flex-wrap gap-2 p-4 bg-card border rounded-lg">
         <span className="text-sm text-slate-600 mr-2">Sort by:</span>
         <SortButton field="title">Title</SortButton>
         <SortButton field="artist">Artist</SortButton>
@@ -131,7 +131,7 @@ export function ItemsList({ items, onItemClick, selectedIds = [], onSelectionCha
                       e.stopPropagation();
                       toggle(item.id.toString(), idx, false);
                     }}
-                    className="absolute -left-3 top-1 bg-white rounded-sm"
+                    className="absolute -left-3 top-1 bg-card rounded-sm"
                   />
                 )}
                 <img

--- a/src/components/ItemsTable.tsx
+++ b/src/components/ItemsTable.tsx
@@ -118,7 +118,7 @@ export function ItemsTable({ items, onItemClick, onSort, sortField, sortDirectio
                         e.stopPropagation();
                         toggle(item.id.toString(), idx, false);
                       }}
-                      className="bg-white rounded-sm"
+                      className="bg-card rounded-sm"
                     />
                   )}
                   <div className="w-12 h-12 rounded overflow-hidden">

--- a/src/components/MultiSelectFilter.tsx
+++ b/src/components/MultiSelectFilter.tsx
@@ -95,7 +95,7 @@ export function MultiSelectFilter({ placeholder, options, selectedValues, onSele
               return (
                 <div
                   key={option.id}
-                  className="px-2 py-1 text-sm font-medium text-slate-600 bg-slate-50"
+                  className="px-2 py-1 text-sm font-medium text-slate-600 bg-muted"
                 >
                   {option.name}
                 </div>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -17,7 +17,7 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
   if (isAuthenticated === null) {
     // Loading state
     return (
-      <div className="min-h-screen bg-slate-50 flex items-center justify-center">
+      <div className="min-h-screen bg-background flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-4"></div>
           <p className="text-slate-600">Loading...</p>

--- a/src/components/SearchFilters.tsx
+++ b/src/components/SearchFilters.tsx
@@ -83,7 +83,7 @@ export function SearchFilters({
       {/* Search and filters in aligned grid */}
       <div
         className={cn(
-          "bg-white p-4 rounded-lg border shadow-sm relative",
+          "bg-card p-4 rounded-lg border shadow-sm relative",
           activeCount > 0 && "border-primary"
         )}
       >

--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -98,7 +98,7 @@ export function AppliedFilters({
   if (!hasActiveFilters) return null;
 
   return (
-    <div className="bg-white p-4 rounded-lg border shadow-sm">
+    <div className="bg-card p-4 rounded-lg border shadow-sm">
       <div className="flex items-center justify-between mb-3">
         <h4 className="text-sm font-medium text-slate-700">Applied Filters</h4>
         <Button variant="ghost" size="sm" onClick={clearAllFilters}>

--- a/src/components/filters/FilterHeader.tsx
+++ b/src/components/filters/FilterHeader.tsx
@@ -15,7 +15,7 @@ export function FilterHeader({
   onDownloadCSV,
 }: FilterHeaderProps) {
   return (
-    <div className="flex items-center justify-between bg-white p-4 rounded-lg border shadow-sm">
+    <div className="flex items-center justify-between bg-card p-4 rounded-lg border shadow-sm">
       <h3 className="text-lg font-semibold text-slate-900">Filter & View Options</h3>
       <div className="flex items-center gap-2">
         {onDownloadCSV && (

--- a/src/index.css
+++ b/src/index.css
@@ -103,3 +103,20 @@ All colors MUST be HSL.
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .dark .bg-white {
+    @apply bg-card;
+  }
+  .dark .bg-slate-50 {
+    @apply bg-muted;
+  }
+  .dark .text-slate-900 {
+    @apply text-foreground;
+  }
+  .dark .text-slate-700,
+  .dark .text-slate-600,
+  .dark .text-slate-500,
+  .dark .text-slate-400 {
+    @apply text-muted-foreground;
+  }}


### PR DESCRIPTION
## Summary
- use theme-aware tokens in components that were stuck on white backgrounds
- adjust global styles so slate text colours switch in dark mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ed9a01158832599a1288e2eab0ae7