### PR TITLE
Add room editing

### DIFF
--- a/src/components/SettingsManagement.tsx
+++ b/src/components/SettingsManagement.tsx
@@ -16,7 +16,8 @@ export function SettingsManagement() {
     addCategory, 
     addHouse, 
     editHouse,
-    addRoom, 
+    editRoom,
+    addRoom,
     deleteRoom,
     addSubcategory, 
     deleteSubcategory,
@@ -78,10 +79,11 @@ export function SettingsManagement() {
         </TabsList>
         
         <TabsContent value="houses">
-          <HousesManagement 
-            houses={houses} 
-            onAddHouse={addHouse} 
+          <HousesManagement
+            houses={houses}
+            onAddHouse={addHouse}
             onAddRoom={addRoom}
+            onEditRoom={editRoom}
             onEditHouse={editHouse}
             onDeleteRoom={deleteRoom}
           />

--- a/src/components/settings/HousesManagement.tsx
+++ b/src/components/settings/HousesManagement.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Plus, X, Download, Edit, Save } from "lucide-react";
 import { IconSelector } from "@/components/IconSelector";
@@ -14,6 +15,8 @@ import {
   SelectTrigger,
   SelectValue
 } from "@/components/ui/select";
+import { API_URL } from "@/lib/api/common";
+import type { RoomConfig } from "@/types/inventory";
 
 const countries = [
   "United States", "Canada", "United Kingdom", "France", "Germany", "Italy", "Spain", 
@@ -23,12 +26,13 @@ const countries = [
 interface HousesManagementProps {
   houses: any[];
   onAddHouse: (name: string, country: string, address: string, yearBuilt: number | undefined, code: string, icon: string) => void;
-  onAddRoom: (houseId: string, roomName: string) => void;
+  onAddRoom: (houseId: string, room: Partial<RoomConfig> & { name: string; floor: number }) => void;
+  onEditRoom?: (houseId: string, roomId: string, updates: Partial<RoomConfig>) => void;
   onEditHouse?: (houseId: string, updates: any) => void;
   onDeleteRoom?: (houseId: string, roomId: string) => void;
 }
 
-export function HousesManagement({ houses, onAddHouse, onAddRoom, onEditHouse, onDeleteRoom }: HousesManagementProps) {
+export function HousesManagement({ houses, onAddHouse, onAddRoom, onEditRoom, onEditHouse, onDeleteRoom }: HousesManagementProps) {
   const [newHouseName, setNewHouseName] = useState("");
   const [newHouseCountry, setNewHouseCountry] = useState("");
   const [newHouseAddress, setNewHouseAddress] = useState("");
@@ -36,11 +40,28 @@ export function HousesManagement({ houses, onAddHouse, onAddRoom, onEditHouse, o
   const [newHouseCode, setNewHouseCode] = useState("");
   const [newHouseIcon, setNewHouseIcon] = useState("house");
   const [newRoomName, setNewRoomName] = useState("");
+  const [newRoomFloor, setNewRoomFloor] = useState("");
+  const [newRoomType, setNewRoomType] = useState("");
+  const [newRoomArea, setNewRoomArea] = useState("");
+  const [newRoomWindows, setNewRoomWindows] = useState("");
+  const [newRoomDoors, setNewRoomDoors] = useState("");
+  const [newRoomDescription, setNewRoomDescription] = useState("");
+  const [newRoomNotes, setNewRoomNotes] = useState("");
+  const [roomTypes, setRoomTypes] = useState<string[]>([]);
   const [selectedHouse, setSelectedHouse] = useState("");
   const [editingHouse, setEditingHouse] = useState<string | null>(null);
   const [editData, setEditData] = useState<any>({});
+  const [editingRoom, setEditingRoom] = useState<string | null>(null);
+  const [roomEditData, setRoomEditData] = useState<any>({});
 
   const { toast } = useToast();
+
+  useEffect(() => {
+    fetch(`${API_URL}/roomtypes`)
+      .then(res => res.ok ? res.json() : [])
+      .then(data => setRoomTypes(Array.isArray(data) ? data : []))
+      .catch(() => setRoomTypes([]));
+  }, []);
 
   const handleAddHouse = () => {
     if (newHouseName.trim() && newHouseCountry.trim() && newHouseCode.trim()) {
@@ -76,19 +97,35 @@ export function HousesManagement({ houses, onAddHouse, onAddRoom, onEditHouse, o
   };
 
   const handleAddRoom = () => {
-    if (newRoomName.trim() && selectedHouse) {
-      onAddRoom(selectedHouse, newRoomName);
-      
+    if (newRoomName.trim() && newRoomFloor.trim() && selectedHouse) {
+      onAddRoom(selectedHouse, {
+        name: newRoomName,
+        floor: parseInt(newRoomFloor, 10),
+        room_type: newRoomType || undefined,
+        area_sqm: newRoomArea ? parseFloat(newRoomArea) : undefined,
+        windows: newRoomWindows ? parseInt(newRoomWindows, 10) : undefined,
+        doors: newRoomDoors ? parseInt(newRoomDoors, 10) : undefined,
+        description: newRoomDescription || undefined,
+        notes: newRoomNotes || undefined,
+      });
+
       toast({
         title: "Room added",
         description: `${newRoomName} has been added successfully`
       });
-      
+
       setNewRoomName("");
+      setNewRoomFloor("");
+      setNewRoomType("");
+      setNewRoomArea("");
+      setNewRoomWindows("");
+      setNewRoomDoors("");
+      setNewRoomDescription("");
+      setNewRoomNotes("");
     } else {
       toast({
         title: "Missing information",
-        description: "Please select a house and enter room name",
+        description: "Please fill in required fields",
         variant: "destructive"
       });
     }
@@ -159,6 +196,46 @@ export function HousesManagement({ houses, onAddHouse, onAddRoom, onEditHouse, o
         description: "Room has been removed successfully"
       });
     }
+  };
+
+  const handleEditRoom = (room: RoomConfig) => {
+    setEditingRoom(room.id);
+    setRoomEditData({
+      name: room.name,
+      floor: room.floor?.toString() || "",
+      room_type: room.room_type || "",
+      area_sqm: room.area_sqm?.toString() || "",
+      windows: room.windows?.toString() || "",
+      doors: room.doors?.toString() || "",
+      description: room.description || "",
+      notes: room.notes || "",
+    });
+  };
+
+  const handleSaveRoomEdit = () => {
+    if (!editingRoom || !selectedHouse) return;
+    if (roomEditData.name.trim() && roomEditData.floor.trim()) {
+      onEditRoom?.(selectedHouse, editingRoom, {
+        name: roomEditData.name,
+        floor: parseInt(roomEditData.floor, 10),
+        room_type: roomEditData.room_type || undefined,
+        area_sqm: roomEditData.area_sqm ? parseFloat(roomEditData.area_sqm) : undefined,
+        windows: roomEditData.windows ? parseInt(roomEditData.windows, 10) : undefined,
+        doors: roomEditData.doors ? parseInt(roomEditData.doors, 10) : undefined,
+        description: roomEditData.description || undefined,
+        notes: roomEditData.notes || undefined,
+      });
+      toast({ title: "Room updated", description: "Room has been updated" });
+      setEditingRoom(null);
+      setRoomEditData({});
+    } else {
+      toast({ title: "Missing information", description: "Please fill in required fields", variant: "destructive" });
+    }
+  };
+
+  const handleCancelRoomEdit = () => {
+    setEditingRoom(null);
+    setRoomEditData({});
   };
 
   const downloadHousesTemplate = () => {
@@ -395,19 +472,179 @@ export function HousesManagement({ houses, onAddHouse, onAddRoom, onEditHouse, o
             </Select>
           </div>
           
-          <div className="flex gap-2">
-            <Input
-              placeholder="Room name"
-              value={newRoomName}
-              onChange={(e) => setNewRoomName(e.target.value)}
-              className="flex-1"
-              disabled={!selectedHouse}
-            />
-            <Button onClick={handleAddRoom} disabled={!selectedHouse}>
-              <Plus className="w-4 h-4 mr-1" />
-              Add Room
-            </Button>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <Label>Room Name *</Label>
+              <Input
+                placeholder="Room name"
+                value={newRoomName}
+                onChange={(e) => setNewRoomName(e.target.value)}
+                disabled={!selectedHouse}
+              />
+            </div>
+            <div>
+              <Label>Floor *</Label>
+              <Input
+                type="number"
+                placeholder="0"
+                value={newRoomFloor}
+                onChange={(e) => setNewRoomFloor(e.target.value)}
+                disabled={!selectedHouse}
+              />
+            </div>
+            <div>
+              <Label>Room Type</Label>
+              <Select value={newRoomType} onValueChange={setNewRoomType} disabled={!selectedHouse}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select type" />
+                </SelectTrigger>
+                <SelectContent>
+                  {roomTypes.map((t) => (
+                    <SelectItem key={t} value={t}>{t}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label>Area (sqm)</Label>
+              <Input
+                type="number"
+                step="0.01"
+                placeholder="0"
+                value={newRoomArea}
+                onChange={(e) => setNewRoomArea(e.target.value)}
+                disabled={!selectedHouse}
+              />
+            </div>
+            <div>
+              <Label>Windows</Label>
+              <Input
+                type="number"
+                placeholder="0"
+                value={newRoomWindows}
+                onChange={(e) => setNewRoomWindows(e.target.value)}
+                disabled={!selectedHouse}
+              />
+            </div>
+            <div>
+              <Label>Doors</Label>
+              <Input
+                type="number"
+                placeholder="0"
+                value={newRoomDoors}
+                onChange={(e) => setNewRoomDoors(e.target.value)}
+                disabled={!selectedHouse}
+              />
+            </div>
+            <div className="md:col-span-2">
+              <Label>Description</Label>
+              <Textarea
+                value={newRoomDescription}
+                onChange={(e) => setNewRoomDescription(e.target.value)}
+                rows={2}
+              />
+            </div>
+            <div className="md:col-span-2">
+              <Label>Notes</Label>
+              <Textarea
+                value={newRoomNotes}
+                onChange={(e) => setNewRoomNotes(e.target.value)}
+                rows={2}
+              />
+            </div>
           </div>
+
+          <Button onClick={handleAddRoom} disabled={!selectedHouse} className="mt-2">
+            <Plus className="w-4 h-4 mr-1" />
+            Add Room
+          </Button>
+
+          {editingRoom && (
+            <div className="mt-6 space-y-4">
+              <Label>Edit Room</Label>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <Label>Room Name *</Label>
+                  <Input
+                    value={roomEditData.name || ""}
+                    onChange={(e) => setRoomEditData({ ...roomEditData, name: e.target.value })}
+                  />
+                </div>
+                <div>
+                  <Label>Floor *</Label>
+                  <Input
+                    type="number"
+                    value={roomEditData.floor || ""}
+                    onChange={(e) => setRoomEditData({ ...roomEditData, floor: e.target.value })}
+                  />
+                </div>
+                <div>
+                  <Label>Room Type</Label>
+                  <Select value={roomEditData.room_type || ""} onValueChange={(val) => setRoomEditData({ ...roomEditData, room_type: val })}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {roomTypes.map(t => (
+                        <SelectItem key={t} value={t}>{t}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div>
+                  <Label>Area (sqm)</Label>
+                  <Input
+                    type="number"
+                    step="0.01"
+                    value={roomEditData.area_sqm || ""}
+                    onChange={(e) => setRoomEditData({ ...roomEditData, area_sqm: e.target.value })}
+                  />
+                </div>
+                <div>
+                  <Label>Windows</Label>
+                  <Input
+                    type="number"
+                    value={roomEditData.windows || ""}
+                    onChange={(e) => setRoomEditData({ ...roomEditData, windows: e.target.value })}
+                  />
+                </div>
+                <div>
+                  <Label>Doors</Label>
+                  <Input
+                    type="number"
+                    value={roomEditData.doors || ""}
+                    onChange={(e) => setRoomEditData({ ...roomEditData, doors: e.target.value })}
+                  />
+                </div>
+                <div className="md:col-span-2">
+                  <Label>Description</Label>
+                  <Textarea
+                    value={roomEditData.description || ""}
+                    onChange={(e) => setRoomEditData({ ...roomEditData, description: e.target.value })}
+                    rows={2}
+                  />
+                </div>
+                <div className="md:col-span-2">
+                  <Label>Notes</Label>
+                  <Textarea
+                    value={roomEditData.notes || ""}
+                    onChange={(e) => setRoomEditData({ ...roomEditData, notes: e.target.value })}
+                    rows={2}
+                  />
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <Button variant="outline" onClick={handleCancelRoomEdit}>
+                  <X className="w-4 h-4 mr-1" />
+                  Cancel
+                </Button>
+                <Button onClick={handleSaveRoomEdit}>
+                  <Save className="w-4 h-4 mr-1" />
+                  Save
+                </Button>
+              </div>
+            </div>
+          )}
           
           {selectedHouse && (
             <div className="space-y-2">
@@ -418,8 +655,14 @@ export function HousesManagement({ houses, onAddHouse, onAddRoom, onEditHouse, o
                   ?.rooms.map((room) => (
                     <Badge key={room.id} variant="secondary" className="px-3 py-1">
                       {room.name}
-                      <button 
-                        className="ml-2 hover:text-destructive"
+                      <button
+                        className="ml-2 hover:text-primary"
+                        onClick={() => handleEditRoom(room)}
+                      >
+                        <Edit className="w-3 h-3" />
+                      </button>
+                      <button
+                        className="ml-1 hover:text-destructive"
                         onClick={() => handleDeleteRoom(selectedHouse, room.id)}
                       >
                         <X className="w-3 h-3" />

--- a/src/hooks/useSettingsState.ts
+++ b/src/hooks/useSettingsState.ts
@@ -1,6 +1,6 @@
 
 import { useState, useEffect } from "react";
-import { categoryConfigs, defaultHouses, CategoryConfig, HouseConfig } from "@/types/inventory";
+import { categoryConfigs, defaultHouses, CategoryConfig, HouseConfig, RoomConfig } from "@/types/inventory";
 
 // Load persisted settings from localStorage if available
 let storedCategories: CategoryConfig[] | null = null;
@@ -97,17 +97,53 @@ export function useSettingsState() {
     notifyListeners();
   };
 
-  const addRoom = (houseId: string, roomName: string) => {
+  const addRoom = (houseId: string, room: Partial<RoomConfig> & { name: string; floor: number }) => {
     globalHouses = globalHouses.map(house => {
       if (house.id === houseId) {
-        const newRoom = {
-          id: roomName.toLowerCase().replace(/\s+/g, '-'),
-          name: roomName,
-          visible: true
+        const newRoom: RoomConfig = {
+          id: Date.now().toString(),
+          code: room.code,
+          name: room.name,
+          house_code: house.code,
+          room_type: room.room_type,
+          floor: room.floor,
+          area_sqm: room.area_sqm,
+          windows: room.windows,
+          doors: room.doors,
+          description: room.description,
+          notes: room.notes,
+          version: 1,
+          is_deleted: false,
+          visible: true,
         };
         return {
           ...house,
           rooms: [...house.rooms, newRoom]
+        };
+      }
+      return house;
+    });
+    saveState();
+    notifyListeners();
+  };
+
+  const editRoom = (houseId: string, roomId: string, updates: Partial<RoomConfig>) => {
+    globalHouses = globalHouses.map(house => {
+      if (house.id === houseId) {
+        return {
+          ...house,
+          rooms: house.rooms.map(room => {
+            if (room.id === roomId) {
+              const history = room.history ? [...room.history, { ...room }] : [{ ...room }];
+              return {
+                ...room,
+                ...updates,
+                version: (room.version || 1) + 1,
+                history,
+              };
+            }
+            return room;
+          })
         };
       }
       return house;
@@ -201,6 +237,7 @@ export function useSettingsState() {
     addHouse,
     editHouse,
     addRoom,
+    editRoom,
     deleteRoom,
     addSubcategory,
     deleteSubcategory,

--- a/src/lib/api/rooms.ts
+++ b/src/lib/api/rooms.ts
@@ -19,16 +19,16 @@ export async function addRoom(houseId: string, room: RoomConfig) {
     if (!response.ok) throw new Error('Failed to add room');
     const data = await response.json();
     const houses = getAllHouses().map(h =>
-      h.id === houseId ? { ...h, rooms: [...h.rooms, { ...data, deleted: false, history: [] }] } : h
+      h.id === houseId ? { ...h, rooms: [...h.rooms, { ...data, is_deleted: false, history: [] }] } : h
     );
     saveLocalHouses(houses);
     return data;
   } catch {
     const houses = getAllHouses().map(h =>
-      h.id === houseId ? { ...h, rooms: [...h.rooms, { ...room, deleted: false, history: [] }] } : h
+      h.id === houseId ? { ...h, rooms: [...h.rooms, { ...room, is_deleted: false, history: [] }] } : h
     );
     saveLocalHouses(houses);
-    return { ...room, deleted: false, history: [] };
+    return { ...room, is_deleted: false, history: [] };
   }
 }
 
@@ -83,13 +83,13 @@ export async function deleteRoom(houseId: string, roomId: string) {
     });
     if (!response.ok) throw new Error('Failed to delete room');
     const houses = getAllHouses().map(h =>
-      h.id === houseId ? { ...h, rooms: h.rooms.map(r => r.id === roomId ? { ...r, deleted: true } : r) } : h
+      h.id === houseId ? { ...h, rooms: h.rooms.map(r => r.id === roomId ? { ...r, is_deleted: true } : r) } : h
     );
     saveLocalHouses(houses);
     return true;
   } catch {
     const houses = getAllHouses().map(h =>
-      h.id === houseId ? { ...h, rooms: h.rooms.map(r => r.id === roomId ? { ...r, deleted: true } : r) } : h
+      h.id === houseId ? { ...h, rooms: h.rooms.map(r => r.id === roomId ? { ...r, is_deleted: true } : r) } : h
     );
     saveLocalHouses(houses);
     return true;

--- a/src/types/inventory.ts
+++ b/src/types/inventory.ts
@@ -102,9 +102,19 @@ export interface HouseConfig {
 
 export interface RoomConfig {
   id: string;
+  code?: string;
   name: string;
-  visible: boolean;
-  deleted?: boolean;
+  house_code?: string;
+  room_type?: string;
+  floor: number;
+  area_sqm?: number;
+  windows?: number;
+  doors?: number;
+  description?: string;
+  notes?: string;
+  version: number;
+  is_deleted: boolean;
+  visible?: boolean;
   history?: RoomConfig[];
 }
 


### PR DESCRIPTION
## Summary
- add room editing support in Settings state and UI
- expose editRoom hook and wire up to Settings
- enhance room list with edit and delete buttons
- include editable form for rooms

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686ee6494b9c8325bf3eaa86c5dbfb78