### PR TITLE
Add batch actions toolbar to category and house pages

### DIFF
--- a/src/components/BatchLocationDialog.tsx
+++ b/src/components/BatchLocationDialog.tsx
@@ -1,0 +1,60 @@
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { HierarchicalHouseRoomSelector } from "@/components/HierarchicalHouseRoomSelector";
+
+interface BatchLocationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (house: string, room: string) => void;
+}
+
+export function BatchLocationDialog({ open, onOpenChange, onSubmit }: BatchLocationDialogProps) {
+  const [house, setHouse] = useState<string>("");
+  const [room, setRoom] = useState<string>("");
+
+  useEffect(() => {
+    if (!open) {
+      setHouse("");
+      setRoom("");
+    }
+  }, [open]);
+
+  const handleSave = () => {
+    onSubmit(house, room);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Change Location</DialogTitle>
+        </DialogHeader>
+        <div className="py-4">
+          <HierarchicalHouseRoomSelector
+            selectedHouse={house}
+            selectedRoom={room}
+            onSelectionChange={(h, r) => {
+              setHouse(h);
+              setRoom(r);
+            }}
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!house || !room}>
+            Update
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/pages/AllItems.tsx
+++ b/src/pages/AllItems.tsx
@@ -12,7 +12,9 @@ import { ItemDetailDialog } from "@/components/ItemDetailDialog";
 import { ItemHistoryDialog } from "@/components/ItemHistoryDialog";
 import { EmptyState } from "@/components/EmptyState";
 import { sampleDecorItems } from "@/data/sampleData";
-import { fetchDecorItems, deleteDecorItem, restoreDecorItem } from "@/lib/api";
+import { fetchDecorItems, deleteDecorItem, restoreDecorItem, updateDecorItem } from "@/lib/api";
+import { BatchLocationDialog } from "@/components/BatchLocationDialog";
+import { Button } from "@/components/ui/button";
 import { DecorItem } from "@/types/inventory";
 import { useSettingsState } from "@/hooks/useSettingsState";
 import { sortInventoryItems } from "@/lib/sortUtils";
@@ -35,6 +37,7 @@ const AllItems = () => {
   const [selectedItem, setSelectedItem] = useState<DecorItem | null>(null);
   const [historyItem, setHistoryItem] = useState<DecorItem | null>(null);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [locationDialogOpen, setLocationDialogOpen] = useState(false);
   const [sortField, setSortField] = useState<string>("");
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const { houses, categories } = useSettingsState();
@@ -173,6 +176,52 @@ const AllItems = () => {
     URL.revokeObjectURL(url);
   };
 
+  const handleBatchLocation = (house: string, room: string) => {
+    const ids = [...selectedIds];
+    downloadCSV();
+    Promise.all(ids.map(id => updateDecorItem(id, { house, room } as unknown as DecorItem)))
+      .then(updated => {
+        setItems(prev => prev.map(it => {
+          const match = updated.find(u => u.id === it.id);
+          return match ? match : it;
+        }));
+        toast({
+          title: 'Items updated',
+          description: `${ids.length} item${ids.length === 1 ? '' : 's'} moved`,
+        });
+        setSelectedIds([]);
+      })
+      .catch(() => {
+        toast({
+          title: 'Error updating items',
+          description: 'There was a problem updating the selected items',
+          variant: 'destructive',
+        });
+      });
+  };
+
+  const handleBatchDelete = () => {
+    if (!window.confirm(`Delete ${selectedIds.length} item${selectedIds.length === 1 ? '' : 's'}?`)) return;
+    const ids = [...selectedIds];
+    downloadCSV();
+    Promise.all(ids.map(id => deleteDecorItem(id)))
+      .then(() => {
+        setItems(prev => prev.filter(i => !ids.includes(i.id.toString())));
+        toast({
+          title: 'Items deleted',
+          description: `${ids.length} item${ids.length === 1 ? '' : 's'} removed`,
+        });
+        setSelectedIds([]);
+      })
+      .catch(() => {
+        toast({
+          title: 'Error deleting items',
+          description: 'There was a problem deleting the selected items',
+          variant: 'destructive',
+        });
+      });
+  };
+
 
   return (
     <SidebarProvider>
@@ -213,14 +262,24 @@ const AllItems = () => {
             />
 
             {selectedIds.length > 0 && (
-              <div className="mb-6 flex items-center justify-between bg-blue-100 border border-blue-200 text-blue-800 px-4 py-2 rounded">
+              <div className="mb-6 flex flex-wrap items-center justify-between gap-2 bg-blue-100 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 text-blue-800 dark:text-blue-100 px-4 py-2 rounded">
                 <span className="text-sm font-medium">{selectedIds.length} item{selectedIds.length === 1 ? '' : 's'} selected</span>
-                <button
-                  className="text-sm underline"
-                  onClick={() => setSelectedIds([])}
-                >
-                  Clear
-                </button>
+                <div className="flex items-center gap-2">
+                  <Button variant="link" size="sm" onClick={() => setLocationDialogOpen(true)}>
+                    Change Location
+                  </Button>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    className="text-destructive"
+                    onClick={handleBatchDelete}
+                  >
+                    Delete
+                  </Button>
+                  <Button variant="link" size="sm" onClick={() => setSelectedIds([])}>
+                    Clear
+                  </Button>
+                </div>
               </div>
             )}
 
@@ -271,6 +330,11 @@ const AllItems = () => {
               open={!!historyItem}
               onOpenChange={(open) => !open && setHistoryItem(null)}
               onRestore={handleRestore}
+            />
+            <BatchLocationDialog
+              open={locationDialogOpen}
+              onOpenChange={setLocationDialogOpen}
+              onSubmit={handleBatchLocation}
             />
           </main>
         </div>

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -11,7 +11,9 @@ import { ItemDetailDialog } from "@/components/ItemDetailDialog";
 import { ItemHistoryDialog } from "@/components/ItemHistoryDialog";
 import { EmptyState } from "@/components/EmptyState";
 import { sampleDecorItems } from "@/data/sampleData";
-import { fetchDecorItems, deleteDecorItem, restoreDecorItem } from "@/lib/api";
+import { fetchDecorItems, deleteDecorItem, restoreDecorItem, updateDecorItem } from "@/lib/api";
+import { BatchLocationDialog } from "@/components/BatchLocationDialog";
+import { Button } from "@/components/ui/button";
 import { DecorItem } from "@/types/inventory";
 import { useSettingsState } from "@/hooks/useSettingsState";
 import { sortInventoryItems } from "@/lib/sortUtils";
@@ -35,6 +37,7 @@ const CategoryPage = () => {
   const [selectedItem, setSelectedItem] = useState<DecorItem | null>(null);
   const [historyItem, setHistoryItem] = useState<DecorItem | null>(null);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [locationDialogOpen, setLocationDialogOpen] = useState(false);
   const [sortField, setSortField] = useState<string>("");
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const { categories, houses } = useSettingsState();
@@ -183,6 +186,54 @@ const CategoryPage = () => {
     URL.revokeObjectURL(url);
   };
 
+  const handleBatchLocation = (house: string, room: string) => {
+    const ids = [...selectedIds];
+    downloadCSV();
+    Promise.all(ids.map(id => updateDecorItem(id, { house, room } as unknown as DecorItem)))
+      .then(updated => {
+        setItems(prev =>
+          prev.map(it => {
+            const match = updated.find(u => u.id === it.id);
+            return match ? match : it;
+          })
+        );
+        toast({
+          title: 'Items updated',
+          description: `${ids.length} item${ids.length === 1 ? '' : 's'} moved`,
+        });
+        setSelectedIds([]);
+      })
+      .catch(() => {
+        toast({
+          title: 'Error updating items',
+          description: 'There was a problem updating the selected items',
+          variant: 'destructive',
+        });
+      });
+  };
+
+  const handleBatchDelete = () => {
+    if (!window.confirm(`Delete ${selectedIds.length} item${selectedIds.length === 1 ? '' : 's'}?`)) return;
+    const ids = [...selectedIds];
+    downloadCSV();
+    Promise.all(ids.map(id => deleteDecorItem(id)))
+      .then(() => {
+        setItems(prev => prev.filter(i => !ids.includes(i.id.toString())));
+        toast({
+          title: 'Items deleted',
+          description: `${ids.length} item${ids.length === 1 ? '' : 's'} removed`,
+        });
+        setSelectedIds([]);
+      })
+      .catch(() => {
+        toast({
+          title: 'Error deleting items',
+          description: 'There was a problem deleting the selected items',
+          variant: 'destructive',
+        });
+      });
+  };
+
 
   return (
     <SidebarProvider>
@@ -225,14 +276,24 @@ const CategoryPage = () => {
 
 
             {selectedIds.length > 0 && (
-              <div className="mb-6 flex items-center justify-between bg-blue-100 border border-blue-200 text-blue-800 px-4 py-2 rounded">
+              <div className="mb-6 flex flex-wrap items-center justify-between gap-2 bg-blue-100 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 text-blue-800 dark:text-blue-100 px-4 py-2 rounded">
                 <span className="text-sm font-medium">{selectedIds.length} item{selectedIds.length === 1 ? '' : 's'} selected</span>
-                <button
-                  className="text-sm underline"
-                  onClick={() => setSelectedIds([])}
-                >
-                  Clear
-                </button>
+                <div className="flex items-center gap-2">
+                  <Button variant="link" size="sm" onClick={() => setLocationDialogOpen(true)}>
+                    Change Location
+                  </Button>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    className="text-destructive"
+                    onClick={handleBatchDelete}
+                  >
+                    Delete
+                  </Button>
+                  <Button variant="link" size="sm" onClick={() => setSelectedIds([])}>
+                    Clear
+                  </Button>
+                </div>
               </div>
             )}
 
@@ -283,6 +344,11 @@ const CategoryPage = () => {
               open={!!historyItem}
               onOpenChange={(open) => !open && setHistoryItem(null)}
               onRestore={handleRestore}
+            />
+            <BatchLocationDialog
+              open={locationDialogOpen}
+              onOpenChange={setLocationDialogOpen}
+              onSubmit={handleBatchLocation}
             />
           </main>
         </div>

--- a/src/pages/HousePage.tsx
+++ b/src/pages/HousePage.tsx
@@ -12,7 +12,9 @@ import { ItemDetailDialog } from "@/components/ItemDetailDialog";
 import { ItemHistoryDialog } from "@/components/ItemHistoryDialog";
 import { EmptyState } from "@/components/EmptyState";
 import { sampleDecorItems } from "@/data/sampleData";
-import { fetchDecorItems, deleteDecorItem, restoreDecorItem } from "@/lib/api";
+import { fetchDecorItems, deleteDecorItem, restoreDecorItem, updateDecorItem } from "@/lib/api";
+import { BatchLocationDialog } from "@/components/BatchLocationDialog";
+import { Button } from "@/components/ui/button";
 import { DecorItem } from "@/types/inventory";
 import { useSettingsState } from "@/hooks/useSettingsState";
 import { sortInventoryItems } from "@/lib/sortUtils";
@@ -36,6 +38,7 @@ const HousePage = () => {
   const [selectedItem, setSelectedItem] = useState<DecorItem | null>(null);
   const [historyItem, setHistoryItem] = useState<DecorItem | null>(null);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [locationDialogOpen, setLocationDialogOpen] = useState(false);
   const [sortField, setSortField] = useState<string>("");
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const { houses, categories } = useSettingsState();
@@ -172,6 +175,54 @@ const HousePage = () => {
 
   };
 
+  const handleBatchLocation = (house: string, room: string) => {
+    const ids = [...selectedIds];
+    downloadCSV();
+    Promise.all(ids.map(id => updateDecorItem(id, { house, room } as unknown as DecorItem)))
+      .then(updated => {
+        setItems(prev =>
+          prev.map(it => {
+            const match = updated.find(u => u.id === it.id);
+            return match ? match : it;
+          })
+        );
+        toast({
+          title: 'Items updated',
+          description: `${ids.length} item${ids.length === 1 ? '' : 's'} moved`,
+        });
+        setSelectedIds([]);
+      })
+      .catch(() => {
+        toast({
+          title: 'Error updating items',
+          description: 'There was a problem updating the selected items',
+          variant: 'destructive',
+        });
+      });
+  };
+
+  const handleBatchDelete = () => {
+    if (!window.confirm(`Delete ${selectedIds.length} item${selectedIds.length === 1 ? '' : 's'}?`)) return;
+    const ids = [...selectedIds];
+    downloadCSV();
+    Promise.all(ids.map(id => deleteDecorItem(id)))
+      .then(() => {
+        setItems(prev => prev.filter(i => !ids.includes(i.id.toString())));
+        toast({
+          title: 'Items deleted',
+          description: `${ids.length} item${ids.length === 1 ? '' : 's'} removed`,
+        });
+        setSelectedIds([]);
+      })
+      .catch(() => {
+        toast({
+          title: 'Error deleting items',
+          description: 'There was a problem deleting the selected items',
+          variant: 'destructive',
+        });
+      });
+  };
+
   const sortedItems = sortInventoryItems(
     filteredItems,
     sortField,
@@ -226,14 +277,24 @@ const HousePage = () => {
             />
 
             {selectedIds.length > 0 && (
-              <div className="mb-6 flex items-center justify-between bg-blue-100 border border-blue-200 text-blue-800 px-4 py-2 rounded">
+              <div className="mb-6 flex flex-wrap items-center justify-between gap-2 bg-blue-100 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 text-blue-800 dark:text-blue-100 px-4 py-2 rounded">
                 <span className="text-sm font-medium">{selectedIds.length} item{selectedIds.length === 1 ? '' : 's'} selected</span>
-                <button
-                  className="text-sm underline"
-                  onClick={() => setSelectedIds([])}
-                >
-                  Clear
-                </button>
+                <div className="flex items-center gap-2">
+                  <Button variant="link" size="sm" onClick={() => setLocationDialogOpen(true)}>
+                    Change Location
+                  </Button>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    className="text-destructive"
+                    onClick={handleBatchDelete}
+                  >
+                    Delete
+                  </Button>
+                  <Button variant="link" size="sm" onClick={() => setSelectedIds([])}>
+                    Clear
+                  </Button>
+                </div>
               </div>
             )}
 
@@ -284,6 +345,11 @@ const HousePage = () => {
               open={!!historyItem}
               onOpenChange={(open) => !open && setHistoryItem(null)}
               onRestore={handleRestore}
+            />
+            <BatchLocationDialog
+              open={locationDialogOpen}
+              onOpenChange={setLocationDialogOpen}
+              onSubmit={handleBatchLocation}
             />
           </main>
         </div>


### PR DESCRIPTION
## Summary
- refine batch action buttons on AllItems page so they use the Button component
- enable batch location changes and deletions in CategoryPage and HousePage
- export a CSV snapshot before any batch action to allow undo via import
- fix toolbar styling so it works in dark mode

## Testing
- `npm run lint` *(fails: cannot find ESLint packages)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ee80b9f788325a0c733705d358e3c