### PR TITLE
Update house fields and management forms

### DIFF
--- a/src/components/CsvUploader.tsx
+++ b/src/components/CsvUploader.tsx
@@ -126,7 +126,7 @@ export function CsvUploader({ onUpload }: CsvUploaderProps) {
 
         <div className="text-xs text-gray-500">
           <p><strong>CSV Format Examples:</strong></p>
-          <p><strong>Houses:</strong> name,country,address,yearBuilt,code</p>
+          <p><strong>Houses:</strong> name,city,country,address,postal_code,code,beneficiary,latitude,longitude,description,notes</p>
           <p><strong>Categories:</strong> name,icon</p>
           <p><strong>Rooms:</strong> name,houseId</p>
           <p><strong>Items:</strong> title,category,subcategory,house,room,widthCm,heightCm,depthCm,description,valuation,artist</p>

--- a/src/components/SettingsManagement.tsx
+++ b/src/components/SettingsManagement.tsx
@@ -41,8 +41,10 @@ export function SettingsManagement() {
   const downloadCsvMappings = () => {
     // Convert houses to CSV
     const housesCsv = [
-      'House Name,Country,Address,Year Built,Code,Icon',
-      ...houses.map(h => `"${h.name}","${h.country}","${h.address || ''}","${h.yearBuilt || ''}","${h.code}","${h.icon}"`)
+      'House Name,City,Country,Address,Postal Code,Code,Beneficiary,Latitude,Longitude,Description,Notes,Icon',
+      ...houses.map(h =>
+        `"${h.name}","${h.city}","${h.country}","${h.address || ''}","${h.postal_code || ''}","${h.code}","${Array.isArray(h.beneficiary) ? h.beneficiary.join(';') : (h.beneficiary || '')}","${h.latitude ?? ''}","${h.longitude ?? ''}","${h.description || ''}","${h.notes || ''}","${h.icon}"`
+      )
     ].join('\n');
 
     // Convert categories to CSV

--- a/src/components/settings/BulkUpload.tsx
+++ b/src/components/settings/BulkUpload.tsx
@@ -113,7 +113,7 @@ export function BulkUpload({ onUpload }: BulkUploadProps) {
     
     switch (type) {
       case "houses":
-        template = "name,country,address,yearBuilt,code\nMy House,United States,123 Main St,1985,MH01\nGuest House,United States,125 Main St,1990,GH01";
+        template = "name,city,country,address,postal_code,code,beneficiary,latitude,longitude,description,notes\nMy House,Beverly Hills,United States,123 Main St,90210,MH01,John Doe,34.07,-118.4,Primary residence,";
         filename = "houses-template.csv";
         break;
       case "rooms":

--- a/src/components/settings/HousesManagement.tsx
+++ b/src/components/settings/HousesManagement.tsx
@@ -34,10 +34,16 @@ interface HousesManagementProps {
   houses: any[];
   onAddHouse: (
     name: string,
+    city: string,
     country: string,
     address: string,
-    yearBuilt: number | undefined,
+    postalCode: string,
+    beneficiary: string,
+    latitude: number | undefined,
+    longitude: number | undefined,
     code: string,
+    description: string,
+    notes: string,
     icon: string
   ) => void;
   onAddRoom: (houseId: string, room: Partial<RoomConfig> & { name: string; floor: number }) => void;
@@ -63,9 +69,15 @@ export function HousesManagement({
   onToggleRoom
 }: HousesManagementProps) {
   const [newHouseName, setNewHouseName] = useState("");
+  const [newHouseCity, setNewHouseCity] = useState("");
   const [newHouseCountry, setNewHouseCountry] = useState("");
   const [newHouseAddress, setNewHouseAddress] = useState("");
-  const [newHouseYear, setNewHouseYear] = useState("");
+  const [newHousePostal, setNewHousePostal] = useState("");
+  const [newHouseBeneficiary, setNewHouseBeneficiary] = useState("");
+  const [newHouseLatitude, setNewHouseLatitude] = useState("");
+  const [newHouseLongitude, setNewHouseLongitude] = useState("");
+  const [newHouseDescription, setNewHouseDescription] = useState("");
+  const [newHouseNotes, setNewHouseNotes] = useState("");
   const [newHouseCode, setNewHouseCode] = useState("");
   const [newHouseIcon, setNewHouseIcon] = useState("house");
   const [newRoomName, setNewRoomName] = useState("");
@@ -99,7 +111,7 @@ export function HousesManagement({
   }, [selectedHouse]);
 
   const handleAddHouse = () => {
-    if (newHouseName.trim() && newHouseCountry.trim() && newHouseCode.trim()) {
+    if (newHouseName.trim() && newHouseCity.trim() && newHouseCountry.trim() && newHouseCode.trim()) {
       if (newHouseCode.length !== 4) {
         toast({
           title: "Invalid house code",
@@ -108,24 +120,43 @@ export function HousesManagement({
         });
         return;
       }
-      
-      onAddHouse(newHouseName, newHouseCountry, newHouseAddress, newHouseYear ? parseInt(newHouseYear) : undefined, newHouseCode, newHouseIcon);
-      
+
+      onAddHouse(
+        newHouseName,
+        newHouseCity,
+        newHouseCountry,
+        newHouseAddress,
+        newHousePostal,
+        newHouseBeneficiary,
+        newHouseLatitude ? parseFloat(newHouseLatitude) : undefined,
+        newHouseLongitude ? parseFloat(newHouseLongitude) : undefined,
+        newHouseCode,
+        newHouseDescription,
+        newHouseNotes,
+        newHouseIcon
+      );
+
       toast({
         title: "House added",
         description: `${newHouseName} has been added successfully`
       });
-      
+
       setNewHouseName("");
+      setNewHouseCity("");
       setNewHouseCountry("");
       setNewHouseAddress("");
-      setNewHouseYear("");
+      setNewHousePostal("");
+      setNewHouseBeneficiary("");
+      setNewHouseLatitude("");
+      setNewHouseLongitude("");
+      setNewHouseDescription("");
+      setNewHouseNotes("");
       setNewHouseCode("");
       setNewHouseIcon("house");
     } else {
       toast({
         title: "Missing required fields",
-        description: "Please fill in house name, country, and code",
+        description: "Please fill in house name, city, country, and code",
         variant: "destructive"
       });
     }
@@ -170,16 +201,22 @@ export function HousesManagement({
     setEditingHouse(house.id);
     setEditData({
       name: house.name,
+      city: house.city,
       country: house.country,
       address: house.address || "",
-      yearBuilt: house.yearBuilt?.toString() || "",
+      postal_code: house.postal_code || "",
+      beneficiary: Array.isArray(house.beneficiary) ? house.beneficiary.join(';') : (house.beneficiary || ""),
+      latitude: house.latitude?.toString() || "",
+      longitude: house.longitude?.toString() || "",
       code: house.code,
+      description: house.description || "",
+      notes: house.notes || "",
       icon: house.icon
     });
   };
 
   const handleSaveEdit = () => {
-    if (editData.name.trim() && editData.country.trim() && editData.code.trim()) {
+    if (editData.name.trim() && editData.city.trim() && editData.country.trim() && editData.code.trim()) {
       if (editData.code.length !== 4) {
         toast({
           title: "Invalid house code",
@@ -191,10 +228,16 @@ export function HousesManagement({
 
       const updates = {
         name: editData.name,
+        city: editData.city,
         country: editData.country,
         address: editData.address,
-        yearBuilt: editData.yearBuilt ? parseInt(editData.yearBuilt) : undefined,
+        postal_code: editData.postal_code,
+        beneficiary: editData.beneficiary ? editData.beneficiary.split(';').map((b: string) => b.trim()) : undefined,
+        latitude: editData.latitude ? parseFloat(editData.latitude) : undefined,
+        longitude: editData.longitude ? parseFloat(editData.longitude) : undefined,
         code: editData.code.toUpperCase(),
+        description: editData.description || undefined,
+        notes: editData.notes || undefined,
         icon: editData.icon
       };
 
@@ -212,7 +255,7 @@ export function HousesManagement({
     } else {
       toast({
         title: "Missing required fields",
-        description: "Please fill in house name, country, and code",
+        description: "Please fill in house name, city, country, and code",
         variant: "destructive"
       });
     }
@@ -298,7 +341,7 @@ export function HousesManagement({
   };
 
   const downloadHousesTemplate = () => {
-    const template = "name,country,address,yearBuilt,code\nMy House,United States,123 Main St,1985,MH01\nGuest House,United States,125 Main St,1990,GH01";
+    const template = "name,city,country,address,postal_code,code,beneficiary,latitude,longitude,description,notes\nMy House,Beverly Hills,United States,123 Main St,90210,MH01,John Doe,34.07,-118.4,Primary residence,";
     const blob = new Blob([template], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -330,6 +373,14 @@ export function HousesManagement({
               />
             </div>
             <div>
+              <Label>City *</Label>
+              <Input
+                placeholder="City"
+                value={newHouseCity}
+                onChange={(e) => setNewHouseCity(e.target.value)}
+              />
+            </div>
+            <div>
               <Label>Country *</Label>
               <Select
                 value={newHouseCountry}
@@ -357,12 +408,11 @@ export function HousesManagement({
               />
             </div>
             <div>
-              <Label>Year Built</Label>
+              <Label>Postal Code</Label>
               <Input
-                placeholder="e.g., 1985"
-                type="number"
-                value={newHouseYear}
-                onChange={(e) => setNewHouseYear(e.target.value)}
+                placeholder="Postal code"
+                value={newHousePostal}
+                onChange={(e) => setNewHousePostal(e.target.value)}
               />
             </div>
             <div className="md:col-span-2">
@@ -371,6 +421,48 @@ export function HousesManagement({
                 placeholder="Full address"
                 value={newHouseAddress}
                 onChange={(e) => setNewHouseAddress(e.target.value)}
+              />
+            </div>
+            <div className="md:col-span-2">
+              <Label>Beneficiary</Label>
+              <Input
+                placeholder="e.g., John Doe; Jane Doe"
+                value={newHouseBeneficiary}
+                onChange={(e) => setNewHouseBeneficiary(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label>Latitude</Label>
+              <Input
+                type="number"
+                placeholder="Latitude"
+                value={newHouseLatitude}
+                onChange={(e) => setNewHouseLatitude(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label>Longitude</Label>
+              <Input
+                type="number"
+                placeholder="Longitude"
+                value={newHouseLongitude}
+                onChange={(e) => setNewHouseLongitude(e.target.value)}
+              />
+            </div>
+            <div className="md:col-span-2">
+              <Label>Description</Label>
+              <Textarea
+                value={newHouseDescription}
+                onChange={(e) => setNewHouseDescription(e.target.value)}
+                rows={2}
+              />
+            </div>
+            <div className="md:col-span-2">
+              <Label>Notes</Label>
+              <Textarea
+                value={newHouseNotes}
+                onChange={(e) => setNewHouseNotes(e.target.value)}
+                rows={2}
               />
             </div>
           </div>
@@ -419,6 +511,13 @@ export function HousesManagement({
                           />
                         </div>
                         <div>
+                          <Label>City *</Label>
+                          <Input
+                            value={editData.city}
+                            onChange={(e) => setEditData({ ...editData, city: e.target.value })}
+                          />
+                        </div>
+                        <div>
                           <Label>Country *</Label>
                           <Select
                             value={editData.country}
@@ -440,23 +539,61 @@ export function HousesManagement({
                           <Label>House Code * (4 characters)</Label>
                           <Input
                             value={editData.code}
-                            onChange={(e) => setEditData({...editData, code: e.target.value.slice(0, 4)})}
+                            onChange={(e) => setEditData({ ...editData, code: e.target.value.slice(0, 4) })}
                             maxLength={4}
                           />
                         </div>
                         <div>
-                          <Label>Year Built</Label>
+                          <Label>Postal Code</Label>
                           <Input
-                            type="number"
-                            value={editData.yearBuilt}
-                            onChange={(e) => setEditData({...editData, yearBuilt: e.target.value})}
+                            value={editData.postal_code}
+                            onChange={(e) => setEditData({ ...editData, postal_code: e.target.value })}
                           />
                         </div>
                         <div className="md:col-span-2">
                           <Label>Address</Label>
                           <Input
                             value={editData.address}
-                            onChange={(e) => setEditData({...editData, address: e.target.value})}
+                            onChange={(e) => setEditData({ ...editData, address: e.target.value })}
+                          />
+                        </div>
+                        <div className="md:col-span-2">
+                          <Label>Beneficiary</Label>
+                          <Input
+                            value={editData.beneficiary}
+                            onChange={(e) => setEditData({ ...editData, beneficiary: e.target.value })}
+                          />
+                        </div>
+                        <div>
+                          <Label>Latitude</Label>
+                          <Input
+                            type="number"
+                            value={editData.latitude}
+                            onChange={(e) => setEditData({ ...editData, latitude: e.target.value })}
+                          />
+                        </div>
+                        <div>
+                          <Label>Longitude</Label>
+                          <Input
+                            type="number"
+                            value={editData.longitude}
+                            onChange={(e) => setEditData({ ...editData, longitude: e.target.value })}
+                          />
+                        </div>
+                        <div className="md:col-span-2">
+                          <Label>Description</Label>
+                          <Textarea
+                            value={editData.description}
+                            onChange={(e) => setEditData({ ...editData, description: e.target.value })}
+                            rows={2}
+                          />
+                        </div>
+                        <div className="md:col-span-2">
+                          <Label>Notes</Label>
+                          <Textarea
+                            value={editData.notes}
+                            onChange={(e) => setEditData({ ...editData, notes: e.target.value })}
+                            rows={2}
                           />
                         </div>
                       </div>
@@ -489,9 +626,6 @@ export function HousesManagement({
                                 <p className="text-sm text-slate-600">{house.country}</p>
                                 {house.address && (
                                   <p className="text-xs text-slate-500">{house.address}</p>
-                                )}
-                                {house.yearBuilt && (
-                                  <p className="text-xs text-slate-500">Built: {house.yearBuilt}</p>
                                 )}
                                 <p className="text-xs text-slate-500">Code: {house.code}</p>
                               </div>

--- a/src/hooks/useSettingsState.ts
+++ b/src/hooks/useSettingsState.ts
@@ -68,14 +68,35 @@ export function useSettingsState() {
     return newCategory;
   };
 
-  const addHouse = (name: string, country: string, address: string, yearBuilt: number | undefined, code: string, icon: string) => {
+  const addHouse = (
+    name: string,
+    city: string,
+    country: string,
+    address: string,
+    postalCode: string,
+    beneficiary: string,
+    latitude: number | undefined,
+    longitude: number | undefined,
+    code: string,
+    description: string,
+    notes: string,
+    icon: string
+  ) => {
     const newHouse: HouseConfig = {
       id: name.toLowerCase().replace(/\s+/g, '-'),
-      name,
-      country,
-      address,
-      yearBuilt,
       code: code.toUpperCase(),
+      name,
+      address,
+      city,
+      country,
+      postal_code: postalCode,
+      beneficiary: beneficiary ? beneficiary.split(';').map(b => b.trim()) : undefined,
+      latitude,
+      longitude,
+      description: description || undefined,
+      notes: notes || undefined,
+      version: 1,
+      is_deleted: false,
       icon,
       rooms: [],
       visible: true
@@ -89,7 +110,13 @@ export function useSettingsState() {
   const editHouse = (houseId: string, updates: Partial<HouseConfig>) => {
     globalHouses = globalHouses.map(house => {
       if (house.id === houseId) {
-        return { ...house, ...updates };
+        const history = house.history ? [...house.history, { ...house }] : [{ ...house }];
+        return {
+          ...house,
+          ...updates,
+          version: (house.version || 1) + 1,
+          history
+        };
       }
       return house;
     });
@@ -300,11 +327,19 @@ export function useSettingsState() {
     const mappings = {
       houses: houses.map(h => ({
         id: h.id,
-        name: h.name,
-        country: h.country,
-        address: h.address,
-        yearBuilt: h.yearBuilt,
         code: h.code,
+        name: h.name,
+        address: h.address,
+        city: h.city,
+        country: h.country,
+        postal_code: h.postal_code,
+        beneficiary: h.beneficiary,
+        latitude: h.latitude,
+        longitude: h.longitude,
+        description: h.description,
+        notes: h.notes,
+        version: h.version,
+        is_deleted: h.is_deleted,
         icon: h.icon,
         rooms: h.rooms.map(r => ({ id: r.id, name: r.name }))
       })),

--- a/src/lib/api/houses.ts
+++ b/src/lib/api/houses.ts
@@ -22,7 +22,7 @@ function getAllHouses(): HouseConfig[] {
 }
 
 function getLocalHouses(): HouseConfig[] {
-  return getAllHouses().filter(h => !h.deleted);
+  return getAllHouses().filter(h => !h.is_deleted);
 }
 
 function saveLocalHouses(houses: HouseConfig[]) {
@@ -35,7 +35,7 @@ export async function fetchHouses(): Promise<HouseConfig[]> {
     if (!response.ok) throw new Error('Failed to fetch houses');
     const data = await response.json();
     saveLocalHouses(data);
-    return data.filter((h: HouseConfig) => !h.deleted);
+    return data.filter((h: HouseConfig) => !h.is_deleted);
   } catch {
     return getLocalHouses();
   }
@@ -51,11 +51,11 @@ export async function createHouse(house: HouseConfig) {
     if (!response.ok) throw new Error('Failed to create house');
     const data = await response.json();
     const houses = getAllHouses();
-    saveLocalHouses([...houses, { ...data, deleted: false, history: [] }]);
+    saveLocalHouses([...houses, { ...data, is_deleted: false, history: [] }]);
     return data;
   } catch {
     const houses = getAllHouses();
-    const newHouse = { ...house, deleted: false, history: [] };
+    const newHouse = { ...house, is_deleted: false, history: [] };
     saveLocalHouses([...houses, newHouse]);
     return newHouse;
   }
@@ -79,7 +79,12 @@ export async function updateHouse(id: string, updates: Partial<HouseConfig>) {
     const updated = houses.map(h => {
       if (h.id === id) {
         const history = h.history ? [...h.history, { ...h }] : [{ ...h }];
-        updatedHouse = { ...h, ...updates, history };
+        updatedHouse = {
+          ...h,
+          ...updates,
+          version: (h.version || 1) + 1,
+          history
+        };
         return updatedHouse;
       }
       return h;
@@ -95,11 +100,11 @@ export async function deleteHouse(id: string) {
       method: 'DELETE'
     });
     if (!response.ok) throw new Error('Failed to delete house');
-    const houses = getAllHouses().map(h => h.id === id ? { ...h, deleted: true } : h);
+    const houses = getAllHouses().map(h => h.id === id ? { ...h, is_deleted: true } : h);
     saveLocalHouses(houses);
     return true;
   } catch {
-    const houses = getAllHouses().map(h => h.id === id ? { ...h, deleted: true } : h);
+    const houses = getAllHouses().map(h => h.id === id ? { ...h, is_deleted: true } : h);
     saveLocalHouses(houses);
     return true;
   }

--- a/src/types/inventory.ts
+++ b/src/types/inventory.ts
@@ -88,15 +88,22 @@ export interface SubcategoryConfig {
 
 export interface HouseConfig {
   id: string;
+  code: string;
   name: string;
-  country: string;
   address?: string;
-  yearBuilt?: number;
-  code?: string;
+  city: string;
+  country: string;
+  postal_code?: string;
+  beneficiary?: string | string[];
+  latitude?: number;
+  longitude?: number;
+  description?: string;
+  notes?: string;
+  version: number;
+  is_deleted: boolean;
   icon: string;
   rooms: RoomConfig[];
   visible: boolean;
-  deleted?: boolean;
   history?: HouseConfig[];
 }
 
@@ -162,11 +169,19 @@ export const categoryConfigs: CategoryConfig[] = [
 export const defaultHouses: HouseConfig[] = [
   {
     id: "main-house",
-    name: "Main House",
-    country: "United States",
-    address: "123 Main Street, Beverly Hills, CA",
-    yearBuilt: 1985,
     code: "MH01",
+    name: "Main House",
+    address: "123 Main Street",
+    city: "Beverly Hills",
+    country: "United States",
+    postal_code: "90210",
+    beneficiary: ["John Doe"],
+    latitude: 34.0736,
+    longitude: -118.4004,
+    description: "Primary residence",
+    notes: "",
+    version: 1,
+    is_deleted: false,
     icon: "house",
     rooms: [
       { id: "living-room", name: "Living Room", visible: true },
@@ -181,11 +196,19 @@ export const defaultHouses: HouseConfig[] = [
   },
   {
     id: "guest-house",
-    name: "Guest House",
-    country: "United States",
-    address: "125 Main Street, Beverly Hills, CA",
-    yearBuilt: 1990,
     code: "GH01",
+    name: "Guest House",
+    address: "125 Main Street",
+    city: "Beverly Hills",
+    country: "United States",
+    postal_code: "90210",
+    beneficiary: ["John Doe"],
+    latitude: 34.0736,
+    longitude: -118.401,
+    description: "Secondary residence",
+    notes: "",
+    version: 1,
+    is_deleted: false,
     icon: "house",
     rooms: [
       { id: "living-room", name: "Living Room", visible: true },
@@ -197,11 +220,19 @@ export const defaultHouses: HouseConfig[] = [
   },
   {
     id: "studio",
-    name: "Studio",
-    country: "France",
-    address: "45 Rue de Rivoli, Paris",
-    yearBuilt: 2010,
     code: "ST01",
+    name: "Studio",
+    address: "45 Rue de Rivoli",
+    city: "Paris",
+    country: "France",
+    postal_code: "75001",
+    beneficiary: ["John Doe"],
+    latitude: 48.8559,
+    longitude: 2.3601,
+    description: "Workspace",
+    notes: "",
+    version: 1,
+    is_deleted: false,
     icon: "house",
     rooms: [
       { id: "main-area", name: "Main Area", visible: true },


### PR DESCRIPTION
## Summary
- expand `HouseConfig` type with city, postal code, beneficiary and more
- add default values for new house fields
- update house management screens to handle new inputs
- show updated house data in CSV downloads and mappings
- adjust API helpers for new fields and versioning

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ef8a1364483258caf0c78e4c45919