### PR TITLE
Add extended decor item fields

### DIFF
--- a/src/components/AddItemBasicInfo.tsx
+++ b/src/components/AddItemBasicInfo.tsx
@@ -12,24 +12,55 @@ export function AddItemBasicInfo({ formData, setFormData }: AddItemBasicInfoProp
       <h3 className="text-lg font-medium text-slate-900">Core Information</h3>
       
       <div>
-        <Label htmlFor="title">Title *</Label>
+        <Label htmlFor="code">Code</Label>
         <Input
-          id="title"
-          placeholder="Enter item title"
-          value={formData.title}
-          onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+          id="code"
+          placeholder="Internal code"
+          value={formData.code}
+          onChange={(e) => setFormData({ ...formData, code: e.target.value })}
+        />
+      </div>
+
+      <div>
+        <Label htmlFor="name">Name *</Label>
+        <Input
+          id="name"
+          placeholder="Item name"
+          value={formData.name}
+          onChange={(e) => setFormData({ ...formData, name: e.target.value })}
           required
         />
       </div>
 
       <div>
-        <Label htmlFor="artist">Artist/Maker *</Label>
+        <Label htmlFor="creator">Creator *</Label>
         <Input
-          id="artist"
-          placeholder="Artist or maker name"
-          value={formData.artist}
-          onChange={(e) => setFormData({ ...formData, artist: e.target.value })}
+          id="creator"
+          placeholder="Creator or maker name"
+          value={formData.creator}
+          onChange={(e) => setFormData({ ...formData, creator: e.target.value })}
           required
+        />
+      </div>
+
+      <div>
+        <Label htmlFor="origin_region">Origin Region *</Label>
+        <Input
+          id="origin_region"
+          placeholder="Where is it from?"
+          value={formData.origin_region}
+          onChange={(e) => setFormData({ ...formData, origin_region: e.target.value })}
+          required
+        />
+      </div>
+
+      <div>
+        <Label htmlFor="material">Material</Label>
+        <Input
+          id="material"
+          placeholder="e.g., wood, metal"
+          value={formData.material}
+          onChange={(e) => setFormData({ ...formData, material: e.target.value })}
         />
       </div>
 
@@ -41,8 +72,8 @@ export function AddItemBasicInfo({ formData, setFormData }: AddItemBasicInfoProp
             type="number"
             step="0.01"
             placeholder="0"
-            value={formData.widthCm}
-            onChange={(e) => setFormData({ ...formData, widthCm: e.target.value })}
+            value={formData.width_cm}
+            onChange={(e) => setFormData({ ...formData, width_cm: e.target.value })}
           />
         </div>
         <div>
@@ -52,8 +83,8 @@ export function AddItemBasicInfo({ formData, setFormData }: AddItemBasicInfoProp
             type="number"
             step="0.01"
             placeholder="0"
-            value={formData.heightCm}
-            onChange={(e) => setFormData({ ...formData, heightCm: e.target.value })}
+            value={formData.height_cm}
+            onChange={(e) => setFormData({ ...formData, height_cm: e.target.value })}
           />
         </div>
         <div>
@@ -63,10 +94,22 @@ export function AddItemBasicInfo({ formData, setFormData }: AddItemBasicInfoProp
             type="number"
             step="0.01"
             placeholder="0"
-            value={formData.depthCm}
-            onChange={(e) => setFormData({ ...formData, depthCm: e.target.value })}
+            value={formData.depth_cm}
+            onChange={(e) => setFormData({ ...formData, depth_cm: e.target.value })}
           />
         </div>
+      </div>
+
+      <div>
+        <Label htmlFor="weight">Weight (kg)</Label>
+        <Input
+          id="weight"
+          type="number"
+          step="0.01"
+          placeholder="0"
+          value={formData.weight_kg}
+          onChange={(e) => setFormData({ ...formData, weight_kg: e.target.value })}
+        />
       </div>
 
       <div>
@@ -82,12 +125,12 @@ export function AddItemBasicInfo({ formData, setFormData }: AddItemBasicInfoProp
       </div>
 
       <div>
-        <Label htmlFor="yearPeriod">Year/Period *</Label>
+        <Label htmlFor="date_period">Date/Period *</Label>
         <Input
-          id="yearPeriod"
+          id="date_period"
           placeholder="e.g., 1920s, 2023"
-          value={formData.yearPeriod}
-          onChange={(e) => setFormData({ ...formData, yearPeriod: e.target.value })}
+          value={formData.date_period}
+          onChange={(e) => setFormData({ ...formData, date_period: e.target.value })}
           required
         />
       </div>

--- a/src/components/AddItemForm.tsx
+++ b/src/components/AddItemForm.tsx
@@ -18,21 +18,30 @@ export function AddItemForm() {
   const draftId = searchParams.get('draftId');
 
   const [formData, setFormData] = useState({
-    title: "",
-    artist: "",
+    code: "",
+    name: "",
+    creator: "",
+    origin_region: "",
+    material: "",
+    width_cm: "",
+    height_cm: "",
+    depth_cm: "",
+    weight_kg: "",
+    provenance: "",
     category: "",
     subcategory: "",
-    widthCm: "",
-    heightCm: "",
-    depthCm: "",
-    valuation: "",
-    valuationDate: undefined as Date | undefined,
-    valuationPerson: "",
-    valuationCurrency: "EUR",
+    acquisition_value: "",
+    acquisition_date: undefined as Date | undefined,
+    acquisition_currency: "EUR",
+    appraisal_value: "",
+    appraisal_date: undefined as Date | undefined,
+    appraisal_currency: "EUR",
+    appraisal_entity: "",
     quantity: "1",
-    yearPeriod: "",
+    date_period: "",
     house: "",
     room: "",
+    room_code: "",
     description: "",
     notes: "",
     images: [] as string[]
@@ -45,21 +54,30 @@ export function AddItemForm() {
         try {
           const draft = JSON.parse(draftData);
           setFormData({
-            title: draft.title || "",
-            artist: draft.artist || "",
+            code: draft.code || "",
+            name: draft.name || "",
+            creator: draft.creator || "",
+            origin_region: draft.origin_region || "",
+            material: draft.material || "",
+            width_cm: draft.width_cm || "",
+            height_cm: draft.height_cm || "",
+            depth_cm: draft.depth_cm || "",
+            weight_kg: draft.weight_kg || "",
+            provenance: draft.provenance || "",
             category: draft.category || "",
             subcategory: draft.subcategory || "",
-            widthCm: draft.widthCm || "",
-            heightCm: draft.heightCm || "",
-            depthCm: draft.depthCm || "",
-            valuation: draft.valuation || "",
-            valuationDate: draft.valuationDate || undefined,
-            valuationPerson: draft.valuationPerson || "",
-            valuationCurrency: draft.valuationCurrency || "EUR",
+            acquisition_value: draft.acquisition_value || "",
+            acquisition_date: draft.acquisition_date || undefined,
+            acquisition_currency: draft.acquisition_currency || "EUR",
+            appraisal_value: draft.appraisal_value || "",
+            appraisal_date: draft.appraisal_date || undefined,
+            appraisal_currency: draft.appraisal_currency || "EUR",
+            appraisal_entity: draft.appraisal_entity || "",
             quantity: draft.quantity || "1",
-            yearPeriod: draft.yearPeriod || "",
+            date_period: draft.date_period || "",
             house: draft.house || "",
             room: draft.room || "",
+            room_code: draft.room_code || "",
             description: draft.description || "",
             notes: draft.notes || "",
             images: draft.images || []
@@ -95,6 +113,50 @@ export function AddItemForm() {
     e.preventDefault();
     console.log("Form submitted:", formData);
 
+    const requiredFields = [
+      'name',
+      'room_code',
+      'creator',
+      'origin_region',
+      'date_period',
+      'category',
+      'subcategory',
+      'quantity'
+    ];
+    for (const field of requiredFields) {
+      if (!formData[field as keyof typeof formData]) {
+        toast({
+          title: 'Missing information',
+          description: `Field "${field}" is required`,
+          variant: 'destructive'
+        });
+        return;
+      }
+    }
+
+    const hasAcq =
+      formData.acquisition_date || formData.acquisition_value || formData.acquisition_currency;
+    if (hasAcq && (!formData.acquisition_date || !formData.acquisition_value || !formData.acquisition_currency)) {
+      toast({
+        title: 'Invalid acquisition data',
+        description: 'Acquisition date, value and currency must all be provided',
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    const hasApp =
+      formData.appraisal_date || formData.appraisal_value || formData.appraisal_currency || formData.appraisal_entity;
+    if (hasApp && (!formData.appraisal_date || !formData.appraisal_value || !formData.appraisal_currency || !formData.appraisal_entity)) {
+      toast({
+        title: 'Invalid appraisal data',
+        description: 'Appraisal date, value, currency and entity must all be provided',
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    const itemData = { ...formData } as unknown as DecorItem;
     let saveAction: Promise<DecorItem | null>;
     let exists = false;
 
@@ -105,13 +167,10 @@ export function AddItemForm() {
       exists = inventory.some((item) => item.id === Number(draftId) && !item.deleted);
 
       saveAction = exists
-        ? updateDecorItem(draftId, {
-            id: Number(draftId),
-            ...formData,
-          })
-        : createDecorItem(formData as unknown as DecorItem);
+        ? updateDecorItem(draftId, { id: Number(draftId), ...itemData })
+        : createDecorItem(itemData);
     } else {
-      saveAction = createDecorItem(formData as unknown as DecorItem);
+      saveAction = createDecorItem(itemData);
     }
 
     saveAction
@@ -148,7 +207,7 @@ export function AddItemForm() {
       id,
       lastModified: new Date().toISOString().split('T')[0],
       data: formData,
-      title: formData.title || 'Untitled Draft',
+      title: formData.name || 'Untitled Draft',
       category: formData.category,
       description: formData.description || '',
     };

--- a/src/components/AddItemLocationValuation.tsx
+++ b/src/components/AddItemLocationValuation.tsx
@@ -17,7 +17,7 @@ interface AddItemLocationValuationProps {
 
 export function AddItemLocationValuation({ formData, setFormData }: AddItemLocationValuationProps) {
   const handleLocationChange = (house: string, room: string) => {
-    setFormData({ ...formData, house, room });
+    setFormData({ ...formData, house, room, room_code: room });
   };
 
   const handleCategoryChange = (category: string, subcategory: string) => {
@@ -40,26 +40,34 @@ export function AddItemLocationValuation({ formData, setFormData }: AddItemLocat
         onSelectionChange={handleLocationChange}
       />
 
+      <div className="space-y-4">
+        <Label htmlFor="provenance">Provenance</Label>
+        <Input
+          id="provenance"
+          placeholder="Where was it acquired from?"
+          value={formData.provenance}
+          onChange={(e) => setFormData({ ...formData, provenance: e.target.value })}
+        />
+      </div>
 
-
-      {/* Valuation Section */}
+      {/* Acquisition Section */}
       <div className="space-y-4 pt-4 border-t">
-        <h4 className="font-medium text-slate-700">Valuation Information</h4>
-        
+        <h4 className="font-medium text-slate-700">Acquisition Information</h4>
+
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <Label htmlFor="valuation">Valuation Amount</Label>
+            <Label htmlFor="acquisition_value">Acquisition Value</Label>
             <Input
-              id="valuation"
+              id="acquisition_value"
               type="number"
               placeholder="0.00"
-              value={formData.valuation}
-              onChange={(e) => setFormData({ ...formData, valuation: e.target.value })}
+              value={formData.acquisition_value}
+              onChange={(e) => setFormData({ ...formData, acquisition_value: e.target.value })}
             />
           </div>
           <div>
-            <Label htmlFor="valuationCurrency">Currency</Label>
-            <Select value={formData.valuationCurrency} onValueChange={(value) => setFormData({ ...formData, valuationCurrency: value })}>
+            <Label htmlFor="acquisition_currency">Currency</Label>
+            <Select value={formData.acquisition_currency} onValueChange={(value) => setFormData({ ...formData, acquisition_currency: value })}>
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
@@ -76,22 +84,79 @@ export function AddItemLocationValuation({ formData, setFormData }: AddItemLocat
         </div>
 
         <div>
-          <Label>Valuation Date</Label>
+          <Label>Acquisition Date</Label>
           <Popover>
             <PopoverTrigger asChild>
               <Button
                 variant="outline"
-                className={`w-full justify-start text-left font-normal ${formData.valuationDate ? "" : "text-muted-foreground"}`}
+                className={`w-full justify-start text-left font-normal ${formData.acquisition_date ? "" : "text-muted-foreground"}`}
               >
                 <CalendarIcon className="mr-2 h-4 w-4" />
-                {formData.valuationDate ? format(formData.valuationDate, "PPP") : "Select date"}
+                {formData.acquisition_date ? format(formData.acquisition_date, "PPP") : "Select date"}
               </Button>
             </PopoverTrigger>
             <PopoverContent className="w-auto p-0" align="start">
               <Calendar
                 mode="single"
-                selected={formData.valuationDate}
-                onSelect={(date) => setFormData({ ...formData, valuationDate: date })}
+                selected={formData.acquisition_date}
+                onSelect={(date) => setFormData({ ...formData, acquisition_date: date })}
+                initialFocus
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+
+      {/* Appraisal Section */}
+      <div className="space-y-4 pt-4 border-t">
+        <h4 className="font-medium text-slate-700">Appraisal Information</h4>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="appraisal_value">Appraisal Value</Label>
+            <Input
+              id="appraisal_value"
+              type="number"
+              placeholder="0.00"
+              value={formData.appraisal_value}
+              onChange={(e) => setFormData({ ...formData, appraisal_value: e.target.value })}
+            />
+          </div>
+          <div>
+            <Label htmlFor="appraisal_currency">Currency</Label>
+            <Select value={formData.appraisal_currency} onValueChange={(value) => setFormData({ ...formData, appraisal_currency: value })}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="USD">USD ($)</SelectItem>
+                <SelectItem value="EUR">EUR (€)</SelectItem>
+                <SelectItem value="GBP">GBP (£)</SelectItem>
+                <SelectItem value="JPY">JPY (¥)</SelectItem>
+                <SelectItem value="CAD">CAD ($)</SelectItem>
+                <SelectItem value="AUD">AUD ($)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div>
+          <Label>Appraisal Date</Label>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                className={`w-full justify-start text-left font-normal ${formData.appraisal_date ? "" : "text-muted-foreground"}`}
+              >
+                <CalendarIcon className="mr-2 h-4 w-4" />
+                {formData.appraisal_date ? format(formData.appraisal_date, "PPP") : "Select date"}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0" align="start">
+              <Calendar
+                mode="single"
+                selected={formData.appraisal_date}
+                onSelect={(date) => setFormData({ ...formData, appraisal_date: date })}
                 initialFocus
               />
             </PopoverContent>
@@ -99,12 +164,12 @@ export function AddItemLocationValuation({ formData, setFormData }: AddItemLocat
         </div>
 
         <div>
-          <Label htmlFor="valuationPerson">Valued By</Label>
+          <Label htmlFor="appraisal_entity">Appraised By</Label>
           <Input
-            id="valuationPerson"
+            id="appraisal_entity"
             placeholder="Appraiser name or organization"
-            value={formData.valuationPerson}
-            onChange={(e) => setFormData({ ...formData, valuationPerson: e.target.value })}
+            value={formData.appraisal_entity}
+            onChange={(e) => setFormData({ ...formData, appraisal_entity: e.target.value })}
           />
         </div>
       </div>

--- a/src/types/inventory.ts
+++ b/src/types/inventory.ts
@@ -26,15 +26,50 @@ export interface ItemBase {
 }
 
 export interface DecorItem extends ItemBase {
-  artist?: string;
+  /** Optional unique code assigned to the item */
+  code?: string;
+  /** Name of the item. `title` from ItemBase remains for backwards compatibility */
+  name?: string;
+  /** Code of the room where the item is located */
+  room_code?: string;
+  /** Creator or artist of the piece */
+  creator?: string;
+  /** Region of origin */
+  origin_region?: string;
+  /** When the piece was created (string/date/number) */
+  date_period?: string | number;
+  /** Material the item is made of */
+  material?: string;
+  height_cm?: number;
+  width_cm?: number;
+  depth_cm?: number;
+  weight_kg?: number;
+  /** Where the item was acquired from */
+  provenance?: string;
   category: string;
   subcategory?: string;
-  size?: string;
-  condition: "mint" | "excellent" | "very good" | "good";
+  quantity?: number;
+  /** Acquisition details */
+  acquisition_date?: string;
+  acquisition_value?: number;
+  acquisition_currency?: string;
+  /** Appraisal details */
+  appraisal_date?: string;
+  appraisal_value?: number;
+  appraisal_currency?: string;
+  appraisal_entity?: string;
+  /** Version number automatically incremented when edited */
+  version?: number;
+  /** Flag used when an item is soft deleted */
+  is_deleted?: boolean;
   /**
    * Keeps previous versions of the item when edits occur.
    */
   history?: DecorItem[];
+  /** Artist field kept for older data sets */
+  artist?: string;
+  size?: string;
+  condition?: "mint" | "excellent" | "very good" | "good";
 }
 
 export interface BookItem extends ItemBase {


### PR DESCRIPTION
## Summary
- add new decor item attributes in type definitions
- update add item forms to handle new mandatory fields
- include provenance, acquisition and appraisal sections
- validate required/acquisition/appraisal fields on submit

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_686efa68c4d88325b47f4c8b3f707bee