### PR TITLE
Allow dev login with demo credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ npm run dev
 
 The app will be available at `http://localhost:5173` by default.
 
+When running `npm run dev`, Vite automatically sets `import.meta.env.DEV` to
+`true`. You do not need to define this variable in your `.env` file.
+
 ## Connecting a FastAPI backend
 
 1. Create a `.env` file based on `.env.example` and set `VITE_API_URL` to the URL of your FastAPI server. If your API requires authentication, also set `VITE_API_KEY` with your key value.

--- a/src/lib/api/login.ts
+++ b/src/lib/api/login.ts
@@ -18,8 +18,8 @@ export async function login(username: string, password: string): Promise<LoginRe
     if (!response.ok) throw new Error('Invalid credentials');
     return response.json();
   } catch {
-    // Fallback to offline authentication
-    if (username === "admin" && password === "password123") {
+    // Fallback to offline authentication in development
+    if (import.meta.env.DEV && username === "admin" && password === "password123") {
       return {
         access_token: "demo_token_" + Date.now(),
         token_type: "Bearer"


### PR DESCRIPTION
## Summary
- gate offline fallback behind `import.meta.env.DEV`
- clarify that Vite sets `import.meta.env.DEV` automatically

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686f713842ec8325bfa3da63b2b040a3