### PR TITLE
Update DecorItem form fields

### DIFF
--- a/src/components/AddItemBasicInfo.tsx
+++ b/src/components/AddItemBasicInfo.tsx
@@ -12,24 +12,55 @@ export function AddItemBasicInfo({ formData, setFormData }: AddItemBasicInfoProp
       <h3 className="text-lg font-medium text-slate-900">Core Information</h3>
       
       <div>
-        <Label htmlFor="title">Title *</Label>
+        <Label htmlFor="code">Code</Label>
         <Input
-          id="title"
-          placeholder="Enter item title"
-          value={formData.title}
-          onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+          id="code"
+          placeholder="Optional code"
+          value={formData.code}
+          onChange={(e) => setFormData({ ...formData, code: e.target.value })}
+        />
+      </div>
+
+      <div>
+        <Label htmlFor="name">Name *</Label>
+        <Input
+          id="name"
+          placeholder="Enter item name"
+          value={formData.name}
+          onChange={(e) => setFormData({ ...formData, name: e.target.value })}
           required
         />
       </div>
 
       <div>
-        <Label htmlFor="artist">Artist/Maker *</Label>
+        <Label htmlFor="creator">Creator *</Label>
         <Input
-          id="artist"
+          id="creator"
           placeholder="Artist or maker name"
-          value={formData.artist}
-          onChange={(e) => setFormData({ ...formData, artist: e.target.value })}
+          value={formData.creator}
+          onChange={(e) => setFormData({ ...formData, creator: e.target.value })}
           required
+        />
+      </div>
+
+      <div>
+        <Label htmlFor="origin">Origin Region *</Label>
+        <Input
+          id="origin"
+          placeholder="Where is it from?"
+          value={formData.originRegion}
+          onChange={(e) => setFormData({ ...formData, originRegion: e.target.value })}
+          required
+        />
+      </div>
+
+      <div>
+        <Label htmlFor="material">Material</Label>
+        <Input
+          id="material"
+          placeholder="What is it made of?"
+          value={formData.material}
+          onChange={(e) => setFormData({ ...formData, material: e.target.value })}
         />
       </div>
 
@@ -70,6 +101,28 @@ export function AddItemBasicInfo({ formData, setFormData }: AddItemBasicInfoProp
       </div>
 
       <div>
+        <Label htmlFor="weight">Weight (kg)</Label>
+        <Input
+          id="weight"
+          type="number"
+          step="0.01"
+          placeholder="0"
+          value={formData.weightKg}
+          onChange={(e) => setFormData({ ...formData, weightKg: e.target.value })}
+        />
+      </div>
+
+      <div>
+        <Label htmlFor="provenance">Provenance</Label>
+        <Input
+          id="provenance"
+          placeholder="Where it was bought or comes from"
+          value={formData.provenance}
+          onChange={(e) => setFormData({ ...formData, provenance: e.target.value })}
+        />
+      </div>
+
+      <div>
         <Label htmlFor="quantity">Quantity *</Label>
         <Input
           id="quantity"
@@ -82,12 +135,12 @@ export function AddItemBasicInfo({ formData, setFormData }: AddItemBasicInfoProp
       </div>
 
       <div>
-        <Label htmlFor="yearPeriod">Year/Period *</Label>
+        <Label htmlFor="datePeriod">Date/Period *</Label>
         <Input
-          id="yearPeriod"
+          id="datePeriod"
           placeholder="e.g., 1920s, 2023"
-          value={formData.yearPeriod}
-          onChange={(e) => setFormData({ ...formData, yearPeriod: e.target.value })}
+          value={formData.datePeriod}
+          onChange={(e) => setFormData({ ...formData, datePeriod: e.target.value })}
           required
         />
       </div>

--- a/src/components/AddItemForm.tsx
+++ b/src/components/AddItemForm.tsx
@@ -18,21 +18,29 @@ export function AddItemForm() {
   const draftId = searchParams.get('draftId');
 
   const [formData, setFormData] = useState({
-    title: "",
-    artist: "",
-    category: "",
-    subcategory: "",
+    code: "",
+    name: "",
+    creator: "",
+    originRegion: "",
+    datePeriod: "",
+    material: "",
     widthCm: "",
     heightCm: "",
     depthCm: "",
-    valuation: "",
-    valuationDate: undefined as Date | undefined,
-    valuationPerson: "",
-    valuationCurrency: "EUR",
+    weightKg: "",
+    provenance: "",
+    category: "",
+    subcategory: "",
     quantity: "1",
-    yearPeriod: "",
     house: "",
-    room: "",
+    room_code: "",
+    acquisitionValue: "",
+    acquisitionDate: undefined as Date | undefined,
+    acquisitionCurrency: "USD",
+    appraisalValue: "",
+    appraisalDate: undefined as Date | undefined,
+    appraisalCurrency: "USD",
+    appraisalEntity: "",
     description: "",
     notes: "",
     images: [] as string[]
@@ -45,21 +53,29 @@ export function AddItemForm() {
         try {
           const draft = JSON.parse(draftData);
           setFormData({
-            title: draft.title || "",
-            artist: draft.artist || "",
-            category: draft.category || "",
-            subcategory: draft.subcategory || "",
+            code: draft.code || "",
+            name: draft.name || draft.title || "",
+            creator: draft.creator || draft.artist || "",
+            originRegion: draft.originRegion || draft.origin_region || "",
+            datePeriod: draft.datePeriod || draft.yearPeriod || "",
+            material: draft.material || "",
             widthCm: draft.widthCm || "",
             heightCm: draft.heightCm || "",
             depthCm: draft.depthCm || "",
-            valuation: draft.valuation || "",
-            valuationDate: draft.valuationDate || undefined,
-            valuationPerson: draft.valuationPerson || "",
-            valuationCurrency: draft.valuationCurrency || "EUR",
+            weightKg: draft.weightKg || draft.weight_kg || "",
+            provenance: draft.provenance || "",
+            category: draft.category || "",
+            subcategory: draft.subcategory || "",
             quantity: draft.quantity || "1",
-            yearPeriod: draft.yearPeriod || "",
             house: draft.house || "",
-            room: draft.room || "",
+            room_code: draft.room_code || draft.room || "",
+            acquisitionValue: draft.acquisitionValue || draft.acquisition_value || "",
+            acquisitionDate: draft.acquisitionDate || draft.acquisition_date || undefined,
+            acquisitionCurrency: draft.acquisitionCurrency || draft.acquisition_currency || "USD",
+            appraisalValue: draft.appraisalValue || draft.appraisal_value || draft.valuation || "",
+            appraisalDate: draft.appraisalDate || draft.appraisal_date || draft.valuationDate || undefined,
+            appraisalCurrency: draft.appraisalCurrency || draft.appraisal_currency || draft.valuationCurrency || "USD",
+            appraisalEntity: draft.appraisalEntity || draft.appraisal_entity || draft.valuationPerson || "",
             description: draft.description || "",
             notes: draft.notes || "",
             images: draft.images || []
@@ -95,30 +111,93 @@ export function AddItemForm() {
     e.preventDefault();
     console.log("Form submitted:", formData);
 
+    const required = [
+      formData.name,
+      formData.room_code,
+      formData.creator,
+      formData.originRegion,
+      formData.datePeriod,
+      formData.category,
+      formData.subcategory,
+      formData.quantity,
+    ];
+
+    if (required.some((v) => !v || v === "")) {
+      toast({
+        title: "Missing required fields",
+        description: "Please fill all mandatory fields before submitting",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const acqProvided =
+      formData.acquisitionDate || formData.acquisitionValue || formData.acquisitionCurrency;
+    if (acqProvided && !(formData.acquisitionDate && formData.acquisitionValue && formData.acquisitionCurrency)) {
+      toast({
+        title: "Incomplete acquisition info",
+        description: "Date, value and currency must all be provided",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const apprProvided =
+      formData.appraisalDate ||
+      formData.appraisalValue ||
+      formData.appraisalCurrency ||
+      formData.appraisalEntity;
+    if (apprProvided && !(formData.appraisalDate && formData.appraisalValue && formData.appraisalCurrency && formData.appraisalEntity)) {
+      toast({
+        title: "Incomplete appraisal info",
+        description: "Date, value, currency and entity must all be provided",
+        variant: "destructive",
+      });
+      return;
+    }
+
     // Create a proper DecorItem object
     const decorItem: DecorItem = {
       id: draftId ? Number(draftId) : 0,
-      title: formData.title,
-      artist: formData.artist,
-      category: formData.category,
-      subcategory: formData.subcategory,
+      code: formData.code || undefined,
+      name: formData.name,
+      title: formData.name,
+      creator: formData.creator,
+      artist: formData.creator,
+      origin_region: formData.originRegion,
+      date_period: formData.datePeriod,
+      yearPeriod: formData.datePeriod,
+      material: formData.material,
       widthCm: formData.widthCm ? Number(formData.widthCm) : undefined,
       heightCm: formData.heightCm ? Number(formData.heightCm) : undefined,
       depthCm: formData.depthCm ? Number(formData.depthCm) : undefined,
-      valuation: formData.valuation ? Number(formData.valuation) : undefined,
-      valuationDate: formData.valuationDate ? formData.valuationDate.toISOString().split('T')[0] : undefined,
-      valuationPerson: formData.valuationPerson,
-      valuationCurrency: formData.valuationCurrency,
+      weight_kg: formData.weightKg ? Number(formData.weightKg) : undefined,
+      provenance: formData.provenance,
+      category: formData.category,
+      subcategory: formData.subcategory,
       quantity: formData.quantity ? Number(formData.quantity) : 1,
-      yearPeriod: formData.yearPeriod,
+      acquisition_value: formData.acquisitionValue ? Number(formData.acquisitionValue) : undefined,
+      acquisition_date: formData.acquisitionDate ? formData.acquisitionDate.toISOString().split('T')[0] : undefined,
+      acquisition_currency: formData.acquisitionCurrency || undefined,
+      appraisal_value: formData.appraisalValue ? Number(formData.appraisalValue) : undefined,
+      appraisal_date: formData.appraisalDate ? formData.appraisalDate.toISOString().split('T')[0] : undefined,
+      appraisal_currency: formData.appraisalCurrency || undefined,
+      appraisal_entity: formData.appraisalEntity || undefined,
+      valuation: formData.appraisalValue ? Number(formData.appraisalValue) : undefined,
+      valuationDate: formData.appraisalDate ? formData.appraisalDate.toISOString().split('T')[0] : undefined,
+      valuationCurrency: formData.appraisalCurrency,
+      valuationPerson: formData.appraisalEntity,
       house: formData.house,
-      room: formData.room,
+      room_code: formData.room_code,
+      room: formData.room_code,
       description: formData.description,
       notes: formData.notes,
       image: formData.images[0] || "/placeholder.svg",
       images: formData.images,
       condition: "good" as const, // Default condition
-      deleted: false
+      version: 1,
+      is_deleted: false,
+      deleted: false,
     };
 
     let saveAction: Promise<DecorItem | null>;
@@ -171,7 +250,7 @@ export function AddItemForm() {
       id,
       lastModified: new Date().toISOString().split('T')[0],
       data: formData,
-      title: formData.title || 'Untitled Draft',
+      title: formData.name || 'Untitled Draft',
       category: formData.category,
       description: formData.description || '',
     };

--- a/src/components/AddItemLocationValuation.tsx
+++ b/src/components/AddItemLocationValuation.tsx
@@ -17,7 +17,7 @@ interface AddItemLocationValuationProps {
 
 export function AddItemLocationValuation({ formData, setFormData }: AddItemLocationValuationProps) {
   const handleLocationChange = (house: string, room: string) => {
-    setFormData({ ...formData, house, room });
+    setFormData({ ...formData, house, room_code: room });
   };
 
   const handleCategoryChange = (category: string, subcategory: string) => {
@@ -36,30 +36,30 @@ export function AddItemLocationValuation({ formData, setFormData }: AddItemLocat
 
       <HierarchicalHouseRoomSelector
         selectedHouse={formData.house}
-        selectedRoom={formData.room}
+        selectedRoom={formData.room_code}
         onSelectionChange={handleLocationChange}
       />
 
 
 
-      {/* Valuation Section */}
+      {/* Acquisition Section */}
       <div className="space-y-4 pt-4 border-t">
-        <h4 className="font-medium text-slate-700">Valuation Information</h4>
-        
+        <h4 className="font-medium text-slate-700">Acquisition Information</h4>
+
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <Label htmlFor="valuation">Valuation Amount</Label>
+            <Label htmlFor="acqValue">Purchase Price</Label>
             <Input
-              id="valuation"
+              id="acqValue"
               type="number"
               placeholder="0.00"
-              value={formData.valuation}
-              onChange={(e) => setFormData({ ...formData, valuation: e.target.value })}
+              value={formData.acquisitionValue}
+              onChange={(e) => setFormData({ ...formData, acquisitionValue: e.target.value })}
             />
           </div>
           <div>
-            <Label htmlFor="valuationCurrency">Currency</Label>
-            <Select value={formData.valuationCurrency} onValueChange={(value) => setFormData({ ...formData, valuationCurrency: value })}>
+            <Label htmlFor="acqCurrency">Currency</Label>
+            <Select value={formData.acquisitionCurrency} onValueChange={(value) => setFormData({ ...formData, acquisitionCurrency: value })}>
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
@@ -76,22 +76,79 @@ export function AddItemLocationValuation({ formData, setFormData }: AddItemLocat
         </div>
 
         <div>
-          <Label>Valuation Date</Label>
+          <Label>Acquisition Date</Label>
           <Popover>
             <PopoverTrigger asChild>
               <Button
                 variant="outline"
-                className={`w-full justify-start text-left font-normal ${formData.valuationDate ? "" : "text-muted-foreground"}`}
+                className={`w-full justify-start text-left font-normal ${formData.acquisitionDate ? "" : "text-muted-foreground"}`}
               >
                 <CalendarIcon className="mr-2 h-4 w-4" />
-                {formData.valuationDate ? format(formData.valuationDate, "PPP") : "Select date"}
+                {formData.acquisitionDate ? format(formData.acquisitionDate, "PPP") : "Select date"}
               </Button>
             </PopoverTrigger>
             <PopoverContent className="w-auto p-0" align="start">
               <Calendar
                 mode="single"
-                selected={formData.valuationDate}
-                onSelect={(date) => setFormData({ ...formData, valuationDate: date })}
+                selected={formData.acquisitionDate}
+                onSelect={(date) => setFormData({ ...formData, acquisitionDate: date })}
+                initialFocus
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+
+      {/* Appraisal Section */}
+      <div className="space-y-4 pt-4 border-t">
+        <h4 className="font-medium text-slate-700">Appraisal Information</h4>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="appValue">Appraisal Value</Label>
+            <Input
+              id="appValue"
+              type="number"
+              placeholder="0.00"
+              value={formData.appraisalValue}
+              onChange={(e) => setFormData({ ...formData, appraisalValue: e.target.value })}
+            />
+          </div>
+          <div>
+            <Label htmlFor="appCurrency">Currency</Label>
+            <Select value={formData.appraisalCurrency} onValueChange={(value) => setFormData({ ...formData, appraisalCurrency: value })}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="USD">USD ($)</SelectItem>
+                <SelectItem value="EUR">EUR (€)</SelectItem>
+                <SelectItem value="GBP">GBP (£)</SelectItem>
+                <SelectItem value="JPY">JPY (¥)</SelectItem>
+                <SelectItem value="CAD">CAD ($)</SelectItem>
+                <SelectItem value="AUD">AUD ($)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div>
+          <Label>Appraisal Date</Label>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                className={`w-full justify-start text-left font-normal ${formData.appraisalDate ? "" : "text-muted-foreground"}`}
+              >
+                <CalendarIcon className="mr-2 h-4 w-4" />
+                {formData.appraisalDate ? format(formData.appraisalDate, "PPP") : "Select date"}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0" align="start">
+              <Calendar
+                mode="single"
+                selected={formData.appraisalDate}
+                onSelect={(date) => setFormData({ ...formData, appraisalDate: date })}
                 initialFocus
               />
             </PopoverContent>
@@ -99,12 +156,12 @@ export function AddItemLocationValuation({ formData, setFormData }: AddItemLocat
         </div>
 
         <div>
-          <Label htmlFor="valuationPerson">Valued By</Label>
+          <Label htmlFor="appEntity">Appraised By</Label>
           <Input
-            id="valuationPerson"
+            id="appEntity"
             placeholder="Appraiser name or organization"
-            value={formData.valuationPerson}
-            onChange={(e) => setFormData({ ...formData, valuationPerson: e.target.value })}
+            value={formData.appraisalEntity}
+            onChange={(e) => setFormData({ ...formData, appraisalEntity: e.target.value })}
           />
         </div>
       </div>

--- a/src/types/inventory.ts
+++ b/src/types/inventory.ts
@@ -26,13 +26,52 @@ export interface ItemBase {
 }
 
 export interface DecorItem extends ItemBase {
-  artist?: string;
+  /** Optional internal code for the item */
+  code?: string;
+  /** Primary display name */
+  name?: string;
+  /** Creator or artist of the piece */
+  creator?: string;
+  /** Room code where the item is located */
+  room_code?: string;
+  /** Region of origin */
+  origin_region?: string;
+  /** Period or year of creation */
+  date_period?: string;
+  /** Construction material */
+  material?: string;
+  /** Width in centimeters */
+  widthCm?: number;
+  /** Height in centimeters */
+  heightCm?: number;
+  /** Depth in centimeters */
+  depthCm?: number;
+  /** Weight in kilograms */
+  weight_kg?: number;
+  /** Provenance information */
+  provenance?: string;
   category: string;
   subcategory?: string;
   size?: string;
-  widthCm?: number;
-  heightCm?: number;
-  depthCm?: number;
+  /** Acquisition date */
+  acquisition_date?: string;
+  /** Acquisition value */
+  acquisition_value?: number;
+  /** Acquisition currency */
+  acquisition_currency?: string;
+  /** Appraisal date */
+  appraisal_date?: string;
+  /** Appraisal value */
+  appraisal_value?: number;
+  /** Appraisal currency */
+  appraisal_currency?: string;
+  /** Entity that performed the appraisal */
+  appraisal_entity?: string;
+  /** Latest revision version */
+  version?: number;
+  /** Marks an item as deleted instead of removing it permanently */
+  is_deleted?: boolean;
+  /** Condition state */
   condition: "mint" | "excellent" | "very good" | "good";
   /**
    * Keeps previous versions of the item when edits occur.


### PR DESCRIPTION
## Summary
- expand `DecorItem` interface with acquisition and appraisal fields
- track new fields when adding decor items
- validate required item fields and acquisition/appraisal groups
- collect new core attributes in the add form

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686f7a490d988325a6d21c72cb1ea533