### PR TITLE
Add house fields and update forms

### DIFF
--- a/src/components/CsvUploader.tsx
+++ b/src/components/CsvUploader.tsx
@@ -126,7 +126,7 @@ export function CsvUploader({ onUpload }: CsvUploaderProps) {
 
         <div className="text-xs text-gray-500">
           <p><strong>CSV Format Examples:</strong></p>
-          <p><strong>Houses:</strong> name,country,address,yearBuilt,code</p>
+          <p><strong>Houses:</strong> name,city,country,address,postal_code,code</p>
           <p><strong>Categories:</strong> name,icon</p>
           <p><strong>Rooms:</strong> name,houseId</p>
           <p><strong>Items:</strong> title,category,subcategory,house,room,widthCm,heightCm,depthCm,description,valuation,artist</p>

--- a/src/components/SettingsManagement.tsx
+++ b/src/components/SettingsManagement.tsx
@@ -39,14 +39,15 @@ export function SettingsManagement() {
   };
 
   const handleAddHouse = (house: Omit<HouseConfig, 'id' | 'rooms'>) => {
-    addHouse(house.name, house.country, house.address || '', house.yearBuilt, house.code || '', house.icon);
+    addHouse(house);
   };
 
   const downloadCsvMappings = () => {
     // Convert houses to CSV
     const housesCsv = [
-      'House Name,Country,Address,Year Built,Code,Icon',
-      ...houses.map(h => `"${h.name}","${h.country}","${h.address || ''}","${h.yearBuilt || ''}","${h.code}","${h.icon}"`)
+      'House Name,City,Country,Address,Postal Code,Code,Icon',
+      ...houses.map(h =>
+        `"${h.name}","${h.city}","${h.country}","${h.address || ''}","${h.postal_code || ''}","${h.code}"`)
     ].join('\n');
 
     // Convert categories to CSV

--- a/src/components/settings/BulkUpload.tsx
+++ b/src/components/settings/BulkUpload.tsx
@@ -113,7 +113,7 @@ export function BulkUpload({ onUpload }: BulkUploadProps) {
     
     switch (type) {
       case "houses":
-        template = "name,country,address,yearBuilt,code\nMy House,United States,123 Main St,1985,MH01\nGuest House,United States,125 Main St,1990,GH01";
+        template = "name,city,country,address,postal_code,code\nMain House,Beverly Hills,United States,123 Main St,90210,MH01\nGuest House,Beverly Hills,United States,125 Main St,90210,GH01";
         filename = "houses-template.csv";
         break;
       case "rooms":

--- a/src/components/settings/HousesManagement.tsx
+++ b/src/components/settings/HousesManagement.tsx
@@ -40,10 +40,17 @@ export function HousesManagement({
 }: HousesManagementProps) {
   const [newHouse, setNewHouse] = useState({
     name: '',
+    code: '',
+    city: '',
     country: '',
     address: '',
+    postal_code: '',
+    beneficiary: '',
+    latitude: '',
+    longitude: '',
+    description: '',
+    notes: '',
     yearBuilt: '',
-    code: '',
     icon: 'home'
   });
   const [newRoom, setNewRoom] = useState({ name: '', houseId: '' });
@@ -62,10 +69,14 @@ export function HousesManagement({
       errors.name = 'House name is required';
     }
     
+    if (!house.city.trim()) {
+      errors.city = 'City is required';
+    }
+
     if (!house.country.trim()) {
       errors.country = 'Country is required';
     }
-    
+
     if (!house.code.trim()) {
       errors.code = 'House code is required';
     } else if (house.code.length !== 4) {
@@ -84,19 +95,37 @@ export function HousesManagement({
     
     onAddHouse({
       name: newHouse.name,
+      code: newHouse.code.toUpperCase(),
+      city: newHouse.city,
       country: newHouse.country,
       address: newHouse.address,
+      postal_code: newHouse.postal_code,
+      beneficiary: newHouse.beneficiary
+        ? newHouse.beneficiary.split(',').map(b => b.trim())
+        : undefined,
+      latitude: newHouse.latitude ? parseFloat(newHouse.latitude) : undefined,
+      longitude: newHouse.longitude ? parseFloat(newHouse.longitude) : undefined,
+      description: newHouse.description || undefined,
+      notes: newHouse.notes || undefined,
       yearBuilt: newHouse.yearBuilt ? parseInt(newHouse.yearBuilt) : undefined,
-      code: newHouse.code.toUpperCase(),
       icon: newHouse.icon,
-      visible: true
+      visible: true,
+      version: 1,
+      is_deleted: false
     });
     setNewHouse({
       name: '',
+      code: '',
+      city: '',
       country: '',
       address: '',
+      postal_code: '',
+      beneficiary: '',
+      latitude: '',
+      longitude: '',
+      description: '',
+      notes: '',
       yearBuilt: '',
-      code: '',
       icon: 'home'
     });
     setValidationErrors({});
@@ -126,10 +155,17 @@ export function HousesManagement({
     if (!editingHouse) return;
     const errors = validateHouse({
       name: editingHouse.name,
+      code: editingHouse.code || '',
+      city: editingHouse.city,
       country: editingHouse.country,
       address: editingHouse.address || '',
+      postal_code: editingHouse.postal_code || '',
+      beneficiary: '',
+      latitude: '',
+      longitude: '',
+      description: '',
+      notes: '',
       yearBuilt: editingHouse.yearBuilt?.toString() || '',
-      code: editingHouse.code || '',
       icon: editingHouse.icon
     });
     
@@ -140,10 +176,17 @@ export function HousesManagement({
     
     onEditHouse(editingHouse.id, {
       name: editingHouse.name,
+      code: editingHouse.code?.toUpperCase(),
+      city: editingHouse.city,
       country: editingHouse.country,
       address: editingHouse.address,
+      postal_code: editingHouse.postal_code,
+      beneficiary: editingHouse.beneficiary,
+      latitude: editingHouse.latitude,
+      longitude: editingHouse.longitude,
+      description: editingHouse.description,
+      notes: editingHouse.notes,
       yearBuilt: editingHouse.yearBuilt,
-      code: editingHouse.code?.toUpperCase(),
       icon: editingHouse.icon
     });
     setValidationErrors({});
@@ -273,8 +316,8 @@ export function HousesManagement({
                 <div className="grid grid-cols-2 gap-4">
                   <div>
                     <Label htmlFor="country">Country *</Label>
-                    <Select 
-                      value={newHouse.country} 
+                    <Select
+                      value={newHouse.country}
                       onValueChange={(value) => {
                         setNewHouse({ ...newHouse, country: value });
                         if (validationErrors.country) {
@@ -315,6 +358,80 @@ export function HousesManagement({
                       <p className="text-sm text-red-500 mt-1">{validationErrors.code}</p>
                     )}
                   </div>
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="city">City *</Label>
+                    <Input
+                      id="city"
+                      value={newHouse.city}
+                      onChange={(e) => {
+                        setNewHouse({ ...newHouse, city: e.target.value });
+                        if (validationErrors.city) {
+                          setValidationErrors({ ...validationErrors, city: '' });
+                        }
+                      }}
+                      placeholder="e.g., Paris"
+                      className={validationErrors.city ? 'border-red-500' : ''}
+                    />
+                    {validationErrors.city && (
+                      <p className="text-sm text-red-500 mt-1">{validationErrors.city}</p>
+                    )}
+                  </div>
+                  <div>
+                    <Label htmlFor="postal">Postal Code</Label>
+                    <Input
+                      id="postal"
+                      value={newHouse.postal_code}
+                      onChange={(e) => setNewHouse({ ...newHouse, postal_code: e.target.value })}
+                      placeholder="e.g., 90210"
+                    />
+                  </div>
+                </div>
+                <div>
+                  <Label htmlFor="beneficiary">Beneficiary (comma separated)</Label>
+                  <Input
+                    id="beneficiary"
+                    value={newHouse.beneficiary}
+                    onChange={(e) => setNewHouse({ ...newHouse, beneficiary: e.target.value })}
+                    placeholder="e.g., Owner, Family"
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="latitude">Latitude</Label>
+                    <Input
+                      id="latitude"
+                      value={newHouse.latitude}
+                      onChange={(e) => setNewHouse({ ...newHouse, latitude: e.target.value })}
+                      placeholder="34.07"
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="longitude">Longitude</Label>
+                    <Input
+                      id="longitude"
+                      value={newHouse.longitude}
+                      onChange={(e) => setNewHouse({ ...newHouse, longitude: e.target.value })}
+                      placeholder="-118.40"
+                    />
+                  </div>
+                </div>
+                <div>
+                  <Label htmlFor="description">Description</Label>
+                  <Input
+                    id="description"
+                    value={newHouse.description}
+                    onChange={(e) => setNewHouse({ ...newHouse, description: e.target.value })}
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="notes">Notes</Label>
+                  <Input
+                    id="notes"
+                    value={newHouse.notes}
+                    onChange={(e) => setNewHouse({ ...newHouse, notes: e.target.value })}
+                  />
                 </div>
                 <div>
                   <Label htmlFor="address">Address</Label>
@@ -418,8 +535,8 @@ export function HousesManagement({
                           <div className="grid grid-cols-2 gap-4">
                             <div>
                               <Label htmlFor="edit-country">Country *</Label>
-                              <Select 
-                                value={editingHouse.country} 
+                              <Select
+                                value={editingHouse.country}
                                 onValueChange={(value) => {
                                   setEditingHouse({ ...editingHouse, country: value });
                                   if (validationErrors.country) {
@@ -459,6 +576,90 @@ export function HousesManagement({
                                 <p className="text-sm text-red-500 mt-1">{validationErrors.code}</p>
                               )}
                             </div>
+                          </div>
+                          <div className="grid grid-cols-2 gap-4">
+                            <div>
+                              <Label htmlFor="edit-city">City *</Label>
+                              <Input
+                                id="edit-city"
+                                value={editingHouse.city}
+                                onChange={(e) => {
+                                  setEditingHouse({ ...editingHouse, city: e.target.value });
+                                  if (validationErrors.city) {
+                                    setValidationErrors({ ...validationErrors, city: '' });
+                                  }
+                                }}
+                                className={validationErrors.city ? 'border-red-500' : ''}
+                              />
+                              {validationErrors.city && (
+                                <p className="text-sm text-red-500 mt-1">{validationErrors.city}</p>
+                              )}
+                            </div>
+                            <div>
+                              <Label htmlFor="edit-postal">Postal Code</Label>
+                              <Input
+                                id="edit-postal"
+                                value={editingHouse.postal_code || ''}
+                                onChange={(e) => setEditingHouse({ ...editingHouse, postal_code: e.target.value })}
+                              />
+                            </div>
+                          </div>
+                          <div>
+                            <Label htmlFor="edit-beneficiary">Beneficiary (comma separated)</Label>
+                            <Input
+                              id="edit-beneficiary"
+                              value={editingHouse.beneficiary ? editingHouse.beneficiary.join(', ') : ''}
+                              onChange={(e) =>
+                                setEditingHouse({
+                                  ...editingHouse,
+                                  beneficiary: e.target.value.split(',').map(b => b.trim())
+                                })
+                              }
+                            />
+                          </div>
+                          <div className="grid grid-cols-2 gap-4">
+                            <div>
+                              <Label htmlFor="edit-latitude">Latitude</Label>
+                              <Input
+                                id="edit-latitude"
+                                value={editingHouse.latitude ?? ''}
+                                onChange={(e) =>
+                                  setEditingHouse({
+                                    ...editingHouse,
+                                    latitude: e.target.value ? parseFloat(e.target.value) : undefined
+                                  })
+                                }
+                              />
+                            </div>
+                            <div>
+                              <Label htmlFor="edit-longitude">Longitude</Label>
+                              <Input
+                                id="edit-longitude"
+                                value={editingHouse.longitude ?? ''}
+                                onChange={(e) =>
+                                  setEditingHouse({
+                                    ...editingHouse,
+                                    longitude: e.target.value ? parseFloat(e.target.value) : undefined
+                                  })
+                                }
+                              />
+                            </div>
+                          </div>
+                          <div>
+                            <Label htmlFor="edit-description">Description</Label>
+                            <Input
+                              id="edit-description"
+                              value={editingHouse.description || ''}
+                              onChange={(e) => setEditingHouse({ ...editingHouse, description: e.target.value })}
+                            />
+                          </div>
+                          <div>
+                            <Label htmlFor="edit-notes">Notes</Label>
+                            <Input
+                              id="edit-notes"
+                              value={editingHouse.notes || ''}
+                              onChange={(e) => setEditingHouse({ ...editingHouse, notes: e.target.value })}
+                            />
                           </div>
                           <div>
                             <Label htmlFor="edit-address">Address</Label>

--- a/src/hooks/useSettingsState.ts
+++ b/src/hooks/useSettingsState.ts
@@ -68,17 +68,12 @@ export function useSettingsState() {
     return newCategory;
   };
 
-  const addHouse = (name: string, country: string, address: string, yearBuilt: number | undefined, code: string, icon: string) => {
+  const addHouse = (house: Omit<HouseConfig, 'id' | 'rooms'>) => {
     const newHouse: HouseConfig = {
-      id: name.toLowerCase().replace(/\s+/g, '-'),
-      name,
-      country,
-      address,
-      yearBuilt,
-      code: code.toUpperCase(),
-      icon,
+      ...house,
+      id: Date.now().toString(),
+      code: house.code.toUpperCase(),
       rooms: [],
-      visible: true
     };
     globalHouses = [...globalHouses, newHouse];
     saveState();
@@ -89,7 +84,13 @@ export function useSettingsState() {
   const editHouse = (houseId: string, updates: Partial<HouseConfig>) => {
     globalHouses = globalHouses.map(house => {
       if (house.id === houseId) {
-        return { ...house, ...updates };
+        const history = house.history ? [...house.history, { ...house }] : [{ ...house }];
+        return {
+          ...house,
+          ...updates,
+          version: (house.version || 1) + 1,
+          history,
+        };
       }
       return house;
     });

--- a/src/lib/api/houses.ts
+++ b/src/lib/api/houses.ts
@@ -22,7 +22,7 @@ function getAllHouses(): HouseConfig[] {
 }
 
 function getLocalHouses(): HouseConfig[] {
-  return getAllHouses().filter(h => !h.deleted);
+  return getAllHouses().filter(h => !h.is_deleted);
 }
 
 function saveLocalHouses(houses: HouseConfig[]) {
@@ -35,7 +35,7 @@ export async function fetchHouses(): Promise<HouseConfig[]> {
     if (!response.ok) throw new Error('Failed to fetch houses');
     const data = await response.json();
     saveLocalHouses(data);
-    return data.filter((h: HouseConfig) => !h.deleted);
+    return data.filter((h: HouseConfig) => !h.is_deleted);
   } catch {
     return getLocalHouses();
   }
@@ -51,11 +51,11 @@ export async function createHouse(house: HouseConfig) {
     if (!response.ok) throw new Error('Failed to create house');
     const data = await response.json();
     const houses = getAllHouses();
-    saveLocalHouses([...houses, { ...data, deleted: false, history: [] }]);
+    saveLocalHouses([...houses, { ...data, is_deleted: false, history: [] }]);
     return data;
   } catch {
     const houses = getAllHouses();
-    const newHouse = { ...house, deleted: false, history: [] };
+    const newHouse = { ...house, is_deleted: false, history: [] };
     saveLocalHouses([...houses, newHouse]);
     return newHouse;
   }
@@ -79,7 +79,7 @@ export async function updateHouse(id: string, updates: Partial<HouseConfig>) {
     const updated = houses.map(h => {
       if (h.id === id) {
         const history = h.history ? [...h.history, { ...h }] : [{ ...h }];
-        updatedHouse = { ...h, ...updates, history };
+        updatedHouse = { ...h, ...updates, version: (h.version || 1) + 1, history };
         return updatedHouse;
       }
       return h;
@@ -95,11 +95,11 @@ export async function deleteHouse(id: string) {
       method: 'DELETE'
     });
     if (!response.ok) throw new Error('Failed to delete house');
-    const houses = getAllHouses().map(h => h.id === id ? { ...h, deleted: true } : h);
+    const houses = getAllHouses().map(h => h.id === id ? { ...h, is_deleted: true } : h);
     saveLocalHouses(houses);
     return true;
   } catch {
-    const houses = getAllHouses().map(h => h.id === id ? { ...h, deleted: true } : h);
+    const houses = getAllHouses().map(h => h.id === id ? { ...h, is_deleted: true } : h);
     saveLocalHouses(houses);
     return true;
   }

--- a/src/types/inventory.ts
+++ b/src/types/inventory.ts
@@ -91,15 +91,23 @@ export interface SubcategoryConfig {
 
 export interface HouseConfig {
   id: string;
+  code: string;
   name: string;
-  country: string;
   address?: string;
+  city: string;
+  country: string;
+  postal_code?: string;
+  beneficiary?: string[];
+  latitude?: number;
+  longitude?: number;
+  description?: string;
+  notes?: string;
   yearBuilt?: number;
-  code?: string;
   icon: string;
   rooms: RoomConfig[];
   visible: boolean;
-  deleted?: boolean;
+  version: number;
+  is_deleted: boolean;
   history?: HouseConfig[];
 }
 
@@ -165,11 +173,20 @@ export const categoryConfigs: CategoryConfig[] = [
 export const defaultHouses: HouseConfig[] = [
   {
     id: "main-house",
-    name: "Main House",
-    country: "United States",
-    address: "123 Main Street, Beverly Hills, CA",
-    yearBuilt: 1985,
     code: "MH01",
+    name: "Main House",
+    address: "123 Main Street, Beverly Hills, CA",
+    city: "Beverly Hills",
+    country: "United States",
+    postal_code: "90210",
+    beneficiary: ["Owner"],
+    latitude: 34.0736,
+    longitude: -118.4004,
+    description: "Primary residence",
+    notes: "",
+    yearBuilt: 1985,
+    version: 1,
+    is_deleted: false,
     icon: "house",
     rooms: [
       { id: "living-room", name: "Living Room", floor: 1, version: 1, is_deleted: false, visible: true },
@@ -184,11 +201,20 @@ export const defaultHouses: HouseConfig[] = [
   },
   {
     id: "guest-house",
-    name: "Guest House",
-    country: "United States",
-    address: "125 Main Street, Beverly Hills, CA",
-    yearBuilt: 1990,
     code: "GH01",
+    name: "Guest House",
+    address: "125 Main Street, Beverly Hills, CA",
+    city: "Beverly Hills",
+    country: "United States",
+    postal_code: "90210",
+    beneficiary: ["Guests"],
+    latitude: 34.0736,
+    longitude: -118.4004,
+    description: "Guest accommodation",
+    notes: "",
+    yearBuilt: 1990,
+    version: 1,
+    is_deleted: false,
     icon: "house",
     rooms: [
       { id: "living-room", name: "Living Room", floor: 1, version: 1, is_deleted: false, visible: true },
@@ -200,11 +226,20 @@ export const defaultHouses: HouseConfig[] = [
   },
   {
     id: "studio",
-    name: "Studio",
-    country: "France",
-    address: "45 Rue de Rivoli, Paris",
-    yearBuilt: 2010,
     code: "ST01",
+    name: "Studio",
+    address: "45 Rue de Rivoli, Paris",
+    city: "Paris",
+    country: "France",
+    postal_code: "75001",
+    beneficiary: ["Artist"],
+    latitude: 48.8559,
+    longitude: 2.3601,
+    description: "Work studio",
+    notes: "",
+    yearBuilt: 2010,
+    version: 1,
+    is_deleted: false,
     icon: "house",
     rooms: [
       { id: "main-area", name: "Main Area", floor: 1, version: 1, is_deleted: false, visible: true },


### PR DESCRIPTION
## Summary
- expand `HouseConfig` with new fields like `city`, `postal_code`, `beneficiary`, coordinates and deletion/version tracking
- include default values for new fields in sample houses
- support new fields in settings forms and validation
- update state hooks and API helpers to handle versioning and deletion
- revise CSV helpers and templates

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686f7a404d648325ace7c1258095751a