### PR TITLE
Remove house yearBuilt field and lock code on edit

### DIFF
--- a/src/components/settings/HousesManagement.tsx
+++ b/src/components/settings/HousesManagement.tsx
@@ -4,20 +4,59 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { IconSelector } from "@/components/IconSelector";
-import { Plus, Edit, Trash2, GripVertical, Eye, EyeOff, ChevronDown, ChevronRight } from "lucide-react";
+import {
+  Plus,
+  Edit,
+  Trash2,
+  GripVertical,
+  Eye,
+  EyeOff,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
 import { HouseConfig, RoomConfig } from "@/types/inventory";
 import { countries } from "@/lib/countries";
 
 interface HousesManagementProps {
   houses: HouseConfig[];
-  onAddHouse: (house: Omit<HouseConfig, 'id' | 'rooms'>) => void;
-  onAddRoom: (houseId: string, room: Omit<RoomConfig, 'id'>) => void;
-  onEditRoom: (houseId: string, roomId: string, updates: Partial<RoomConfig>) => void;
+  onAddHouse: (house: Omit<HouseConfig, "id" | "rooms">) => void;
+  onAddRoom: (houseId: string, room: Omit<RoomConfig, "id">) => void;
+  onEditRoom: (
+    houseId: string,
+    roomId: string,
+    updates: Partial<RoomConfig>,
+  ) => void;
   onEditHouse: (houseId: string, updates: Partial<HouseConfig>) => void;
   onDeleteRoom: (houseId: string, roomId: string) => void;
   onMoveHouse: (dragIndex: number, hoverIndex: number) => void;
@@ -36,53 +75,59 @@ export function HousesManagement({
   onMoveHouse,
   onMoveRoom,
   onToggleHouse,
-  onToggleRoom
+  onToggleRoom,
 }: HousesManagementProps) {
   const [newHouse, setNewHouse] = useState({
-    name: '',
-    code: '',
-    city: '',
-    country: '',
-    address: '',
-    postal_code: '',
-    beneficiary: '',
-    latitude: '',
-    longitude: '',
-    description: '',
-    notes: '',
-    yearBuilt: '',
-    icon: 'home'
+    name: "",
+    code: "",
+    city: "",
+    country: "",
+    address: "",
+    postal_code: "",
+    beneficiary: "",
+    latitude: "",
+    longitude: "",
+    description: "",
+    notes: "",
+    icon: "home",
   });
-  const [newRoom, setNewRoom] = useState({ name: '', houseId: '' });
-  const [editingRoom, setEditingRoom] = useState<{ houseId: string; room: RoomConfig } | null>(null);
+  const [newRoom, setNewRoom] = useState({ name: "", houseId: "" });
+  const [editingRoom, setEditingRoom] = useState<{
+    houseId: string;
+    room: RoomConfig;
+  } | null>(null);
   const [editingHouse, setEditingHouse] = useState<HouseConfig | null>(null);
   const [showAddHouse, setShowAddHouse] = useState(false);
   const [showAddRoom, setShowAddRoom] = useState(false);
-  const [collapsedHouses, setCollapsedHouses] = useState<Set<string>>(new Set());
-  const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
+  const [collapsedHouses, setCollapsedHouses] = useState<Set<string>>(
+    new Set(),
+  );
+  const [validationErrors, setValidationErrors] = useState<
+    Record<string, string>
+  >({});
   const [draggedHouse, setDraggedHouse] = useState<number | null>(null);
 
   const validateHouse = (house: typeof newHouse) => {
     const errors: Record<string, string> = {};
-    
+
     if (!house.name.trim()) {
-      errors.name = 'House name is required';
+      errors.name = "House name is required";
     }
-    
+
     if (!house.city.trim()) {
-      errors.city = 'City is required';
+      errors.city = "City is required";
     }
 
     if (!house.country.trim()) {
-      errors.country = 'Country is required';
+      errors.country = "Country is required";
     }
 
     if (!house.code.trim()) {
-      errors.code = 'House code is required';
+      errors.code = "House code is required";
     } else if (house.code.length !== 4) {
-      errors.code = 'House code must be exactly 4 characters long';
+      errors.code = "House code must be exactly 4 characters long";
     }
-    
+
     return errors;
   };
 
@@ -92,7 +137,7 @@ export function HousesManagement({
       setValidationErrors(errors);
       return;
     }
-    
+
     onAddHouse({
       name: newHouse.name,
       code: newHouse.code.toUpperCase(),
@@ -101,32 +146,32 @@ export function HousesManagement({
       address: newHouse.address,
       postal_code: newHouse.postal_code,
       beneficiary: newHouse.beneficiary
-        ? newHouse.beneficiary.split(',').map(b => b.trim())
+        ? newHouse.beneficiary.split(",").map((b) => b.trim())
         : undefined,
       latitude: newHouse.latitude ? parseFloat(newHouse.latitude) : undefined,
-      longitude: newHouse.longitude ? parseFloat(newHouse.longitude) : undefined,
+      longitude: newHouse.longitude
+        ? parseFloat(newHouse.longitude)
+        : undefined,
       description: newHouse.description || undefined,
       notes: newHouse.notes || undefined,
-      yearBuilt: newHouse.yearBuilt ? parseInt(newHouse.yearBuilt) : undefined,
       icon: newHouse.icon,
       visible: true,
       version: 1,
-      is_deleted: false
+      is_deleted: false,
     });
     setNewHouse({
-      name: '',
-      code: '',
-      city: '',
-      country: '',
-      address: '',
-      postal_code: '',
-      beneficiary: '',
-      latitude: '',
-      longitude: '',
-      description: '',
-      notes: '',
-      yearBuilt: '',
-      icon: 'home'
+      name: "",
+      code: "",
+      city: "",
+      country: "",
+      address: "",
+      postal_code: "",
+      beneficiary: "",
+      latitude: "",
+      longitude: "",
+      description: "",
+      notes: "",
+      icon: "home",
     });
     setValidationErrors({});
     setShowAddHouse(false);
@@ -134,20 +179,22 @@ export function HousesManagement({
 
   const handleAddRoom = () => {
     if (!newRoom.name.trim() || !newRoom.houseId) return;
-    onAddRoom(newRoom.houseId, { 
-      name: newRoom.name, 
+    onAddRoom(newRoom.houseId, {
+      name: newRoom.name,
       floor: 1,
       version: 1,
       is_deleted: false,
-      visible: true 
+      visible: true,
     });
-    setNewRoom({ name: '', houseId: '' });
+    setNewRoom({ name: "", houseId: "" });
     setShowAddRoom(false);
   };
 
   const handleEditRoom = () => {
     if (!editingRoom || !editingRoom.room.name.trim()) return;
-    onEditRoom(editingRoom.houseId, editingRoom.room.id, { name: editingRoom.room.name });
+    onEditRoom(editingRoom.houseId, editingRoom.room.id, {
+      name: editingRoom.room.name,
+    });
     setEditingRoom(null);
   };
 
@@ -155,25 +202,24 @@ export function HousesManagement({
     if (!editingHouse) return;
     const errors = validateHouse({
       name: editingHouse.name,
-      code: editingHouse.code || '',
+      code: editingHouse.code || "",
       city: editingHouse.city,
       country: editingHouse.country,
-      address: editingHouse.address || '',
-      postal_code: editingHouse.postal_code || '',
-      beneficiary: '',
-      latitude: '',
-      longitude: '',
-      description: '',
-      notes: '',
-      yearBuilt: editingHouse.yearBuilt?.toString() || '',
-      icon: editingHouse.icon
+      address: editingHouse.address || "",
+      postal_code: editingHouse.postal_code || "",
+      beneficiary: "",
+      latitude: "",
+      longitude: "",
+      description: "",
+      notes: "",
+      icon: editingHouse.icon,
     });
-    
+
     if (Object.keys(errors).length > 0) {
       setValidationErrors(errors);
       return;
     }
-    
+
     onEditHouse(editingHouse.id, {
       name: editingHouse.name,
       code: editingHouse.code?.toUpperCase(),
@@ -186,8 +232,7 @@ export function HousesManagement({
       longitude: editingHouse.longitude,
       description: editingHouse.description,
       notes: editingHouse.notes,
-      yearBuilt: editingHouse.yearBuilt,
-      icon: editingHouse.icon
+      icon: editingHouse.icon,
     });
     setValidationErrors({});
     setEditingHouse(null);
@@ -205,12 +250,12 @@ export function HousesManagement({
 
   const handleDragStart = (e: React.DragEvent, index: number) => {
     setDraggedHouse(index);
-    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.effectAllowed = "move";
   };
 
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
+    e.dataTransfer.dropEffect = "move";
   };
 
   const handleDrop = (e: React.DragEvent, dropIndex: number) => {
@@ -221,16 +266,24 @@ export function HousesManagement({
     setDraggedHouse(null);
   };
 
-  const handleRoomDragStart = (e: React.DragEvent, houseId: string, roomIndex: number) => {
-    e.dataTransfer.setData('text/plain', `${houseId}:${roomIndex}`);
-    e.dataTransfer.effectAllowed = 'move';
+  const handleRoomDragStart = (
+    e: React.DragEvent,
+    houseId: string,
+    roomIndex: number,
+  ) => {
+    e.dataTransfer.setData("text/plain", `${houseId}:${roomIndex}`);
+    e.dataTransfer.effectAllowed = "move";
   };
 
-  const handleRoomDrop = (e: React.DragEvent, houseId: string, dropIndex: number) => {
+  const handleRoomDrop = (
+    e: React.DragEvent,
+    houseId: string,
+    dropIndex: number,
+  ) => {
     e.preventDefault();
-    const dragData = e.dataTransfer.getData('text/plain');
-    const [dragHouseId, dragRoomIndex] = dragData.split(':');
-    
+    const dragData = e.dataTransfer.getData("text/plain");
+    const [dragHouseId, dragRoomIndex] = dragData.split(":");
+
     if (dragHouseId === houseId && parseInt(dragRoomIndex) !== dropIndex) {
       onMoveRoom(houseId, parseInt(dragRoomIndex), dropIndex);
     }
@@ -255,13 +308,20 @@ export function HousesManagement({
               <div className="space-y-4">
                 <div>
                   <Label htmlFor="house-select">House *</Label>
-                  <Select value={newRoom.houseId} onValueChange={(value) => setNewRoom({ ...newRoom, houseId: value })}>
+                  <Select
+                    value={newRoom.houseId}
+                    onValueChange={(value) =>
+                      setNewRoom({ ...newRoom, houseId: value })
+                    }
+                  >
                     <SelectTrigger>
                       <SelectValue placeholder="Select a house" />
                     </SelectTrigger>
                     <SelectContent>
-                      {houses.map(house => (
-                        <SelectItem key={house.id} value={house.id}>{house.name}</SelectItem>
+                      {houses.map((house) => (
+                        <SelectItem key={house.id} value={house.id}>
+                          {house.name}
+                        </SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
@@ -271,12 +331,19 @@ export function HousesManagement({
                   <Input
                     id="room-name"
                     value={newRoom.name}
-                    onChange={(e) => setNewRoom({ ...newRoom, name: e.target.value })}
+                    onChange={(e) =>
+                      setNewRoom({ ...newRoom, name: e.target.value })
+                    }
                     placeholder="e.g., Living Room, Kitchen"
                   />
                 </div>
                 <div className="flex justify-end gap-2">
-                  <Button variant="outline" onClick={() => setShowAddRoom(false)}>Cancel</Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => setShowAddRoom(false)}
+                  >
+                    Cancel
+                  </Button>
                   <Button onClick={handleAddRoom}>Add Room</Button>
                 </div>
               </div>
@@ -303,14 +370,16 @@ export function HousesManagement({
                     onChange={(e) => {
                       setNewHouse({ ...newHouse, name: e.target.value });
                       if (validationErrors.name) {
-                        setValidationErrors({ ...validationErrors, name: '' });
+                        setValidationErrors({ ...validationErrors, name: "" });
                       }
                     }}
                     placeholder="e.g., Main House, Studio"
-                    className={validationErrors.name ? 'border-red-500' : ''}
+                    className={validationErrors.name ? "border-red-500" : ""}
                   />
                   {validationErrors.name && (
-                    <p className="text-sm text-red-500 mt-1">{validationErrors.name}</p>
+                    <p className="text-sm text-red-500 mt-1">
+                      {validationErrors.name}
+                    </p>
                   )}
                 </div>
                 <div className="grid grid-cols-2 gap-4">
@@ -321,21 +390,32 @@ export function HousesManagement({
                       onValueChange={(value) => {
                         setNewHouse({ ...newHouse, country: value });
                         if (validationErrors.country) {
-                          setValidationErrors({ ...validationErrors, country: '' });
+                          setValidationErrors({
+                            ...validationErrors,
+                            country: "",
+                          });
                         }
                       }}
                     >
-                      <SelectTrigger className={validationErrors.country ? 'border-red-500' : ''}>
+                      <SelectTrigger
+                        className={
+                          validationErrors.country ? "border-red-500" : ""
+                        }
+                      >
                         <SelectValue placeholder="Select a country" />
                       </SelectTrigger>
                       <SelectContent>
-                        {countries.map(country => (
-                          <SelectItem key={country} value={country}>{country}</SelectItem>
+                        {countries.map((country) => (
+                          <SelectItem key={country} value={country}>
+                            {country}
+                          </SelectItem>
                         ))}
                       </SelectContent>
                     </Select>
                     {validationErrors.country && (
-                      <p className="text-sm text-red-500 mt-1">{validationErrors.country}</p>
+                      <p className="text-sm text-red-500 mt-1">
+                        {validationErrors.country}
+                      </p>
                     )}
                   </div>
                   <div>
@@ -347,15 +427,20 @@ export function HousesManagement({
                         const value = e.target.value.toUpperCase().slice(0, 4);
                         setNewHouse({ ...newHouse, code: value });
                         if (validationErrors.code) {
-                          setValidationErrors({ ...validationErrors, code: '' });
+                          setValidationErrors({
+                            ...validationErrors,
+                            code: "",
+                          });
                         }
                       }}
                       placeholder="e.g., MH01"
                       maxLength={4}
-                      className={validationErrors.code ? 'border-red-500' : ''}
+                      className={validationErrors.code ? "border-red-500" : ""}
                     />
                     {validationErrors.code && (
-                      <p className="text-sm text-red-500 mt-1">{validationErrors.code}</p>
+                      <p className="text-sm text-red-500 mt-1">
+                        {validationErrors.code}
+                      </p>
                     )}
                   </div>
                 </div>
@@ -368,14 +453,19 @@ export function HousesManagement({
                       onChange={(e) => {
                         setNewHouse({ ...newHouse, city: e.target.value });
                         if (validationErrors.city) {
-                          setValidationErrors({ ...validationErrors, city: '' });
+                          setValidationErrors({
+                            ...validationErrors,
+                            city: "",
+                          });
                         }
                       }}
                       placeholder="e.g., Paris"
-                      className={validationErrors.city ? 'border-red-500' : ''}
+                      className={validationErrors.city ? "border-red-500" : ""}
                     />
                     {validationErrors.city && (
-                      <p className="text-sm text-red-500 mt-1">{validationErrors.city}</p>
+                      <p className="text-sm text-red-500 mt-1">
+                        {validationErrors.city}
+                      </p>
                     )}
                   </div>
                   <div>
@@ -383,17 +473,26 @@ export function HousesManagement({
                     <Input
                       id="postal"
                       value={newHouse.postal_code}
-                      onChange={(e) => setNewHouse({ ...newHouse, postal_code: e.target.value })}
+                      onChange={(e) =>
+                        setNewHouse({
+                          ...newHouse,
+                          postal_code: e.target.value,
+                        })
+                      }
                       placeholder="e.g., 90210"
                     />
                   </div>
                 </div>
                 <div>
-                  <Label htmlFor="beneficiary">Beneficiary (comma separated)</Label>
+                  <Label htmlFor="beneficiary">
+                    Beneficiary (comma separated)
+                  </Label>
                   <Input
                     id="beneficiary"
                     value={newHouse.beneficiary}
-                    onChange={(e) => setNewHouse({ ...newHouse, beneficiary: e.target.value })}
+                    onChange={(e) =>
+                      setNewHouse({ ...newHouse, beneficiary: e.target.value })
+                    }
                     placeholder="e.g., Owner, Family"
                   />
                 </div>
@@ -403,7 +502,9 @@ export function HousesManagement({
                     <Input
                       id="latitude"
                       value={newHouse.latitude}
-                      onChange={(e) => setNewHouse({ ...newHouse, latitude: e.target.value })}
+                      onChange={(e) =>
+                        setNewHouse({ ...newHouse, latitude: e.target.value })
+                      }
                       placeholder="34.07"
                     />
                   </div>
@@ -412,7 +513,9 @@ export function HousesManagement({
                     <Input
                       id="longitude"
                       value={newHouse.longitude}
-                      onChange={(e) => setNewHouse({ ...newHouse, longitude: e.target.value })}
+                      onChange={(e) =>
+                        setNewHouse({ ...newHouse, longitude: e.target.value })
+                      }
                       placeholder="-118.40"
                     />
                   </div>
@@ -422,7 +525,9 @@ export function HousesManagement({
                   <Input
                     id="description"
                     value={newHouse.description}
-                    onChange={(e) => setNewHouse({ ...newHouse, description: e.target.value })}
+                    onChange={(e) =>
+                      setNewHouse({ ...newHouse, description: e.target.value })
+                    }
                   />
                 </div>
                 <div>
@@ -430,7 +535,9 @@ export function HousesManagement({
                   <Input
                     id="notes"
                     value={newHouse.notes}
-                    onChange={(e) => setNewHouse({ ...newHouse, notes: e.target.value })}
+                    onChange={(e) =>
+                      setNewHouse({ ...newHouse, notes: e.target.value })
+                    }
                   />
                 </div>
                 <div>
@@ -438,17 +545,10 @@ export function HousesManagement({
                   <Input
                     id="address"
                     value={newHouse.address}
-                    onChange={(e) => setNewHouse({ ...newHouse, address: e.target.value })}
+                    onChange={(e) =>
+                      setNewHouse({ ...newHouse, address: e.target.value })
+                    }
                     placeholder="Full address"
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="year-built">Year Built</Label>
-                  <Input
-                    id="year-built"
-                    value={newHouse.yearBuilt}
-                    onChange={(e) => setNewHouse({ ...newHouse, yearBuilt: e.target.value })}
-                    placeholder="e.g., 1985"
                   />
                 </div>
                 <div>
@@ -459,10 +559,15 @@ export function HousesManagement({
                   />
                 </div>
                 <div className="flex justify-end gap-2">
-                  <Button variant="outline" onClick={() => {
-                    setShowAddHouse(false);
-                    setValidationErrors({});
-                  }}>Cancel</Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      setShowAddHouse(false);
+                      setValidationErrors({});
+                    }}
+                  >
+                    Cancel
+                  </Button>
                   <Button onClick={handleAddHouse}>Add House</Button>
                 </div>
               </div>
@@ -473,7 +578,7 @@ export function HousesManagement({
 
       <div className="space-y-4">
         {houses.map((house, houseIndex) => (
-          <Card 
+          <Card
             key={house.id}
             draggable
             onDragStart={(e) => handleDragStart(e, houseIndex)}
@@ -493,7 +598,8 @@ export function HousesManagement({
                       </span>
                     </div>
                     <div className="text-sm text-gray-600 mt-1">
-                      {house.address ? `${house.address.split(',')[0]}, ` : ''}{house.country}
+                      {house.address ? `${house.address.split(",")[0]}, ` : ""}
+                      {house.country}
                     </div>
                   </div>
                 </div>
@@ -502,10 +608,18 @@ export function HousesManagement({
                     checked={house.visible}
                     onCheckedChange={() => onToggleHouse(house.id)}
                   />
-                  {house.visible ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
+                  {house.visible ? (
+                    <Eye className="w-4 h-4" />
+                  ) : (
+                    <EyeOff className="w-4 h-4" />
+                  )}
                   <Dialog>
                     <DialogTrigger asChild>
-                      <Button variant="ghost" size="sm" onClick={() => setEditingHouse(house)}>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setEditingHouse(house)}
+                      >
                         <Edit className="w-4 h-4" />
                       </Button>
                     </DialogTrigger>
@@ -516,20 +630,32 @@ export function HousesManagement({
                       {editingHouse && (
                         <div className="space-y-4">
                           <div>
-                            <Label htmlFor="edit-house-name">House Name *</Label>
+                            <Label htmlFor="edit-house-name">
+                              House Name *
+                            </Label>
                             <Input
                               id="edit-house-name"
                               value={editingHouse.name}
                               onChange={(e) => {
-                                setEditingHouse({ ...editingHouse, name: e.target.value });
+                                setEditingHouse({
+                                  ...editingHouse,
+                                  name: e.target.value,
+                                });
                                 if (validationErrors.name) {
-                                  setValidationErrors({ ...validationErrors, name: '' });
+                                  setValidationErrors({
+                                    ...validationErrors,
+                                    name: "",
+                                  });
                                 }
                               }}
-                              className={validationErrors.name ? 'border-red-500' : ''}
+                              className={
+                                validationErrors.name ? "border-red-500" : ""
+                              }
                             />
                             {validationErrors.name && (
-                              <p className="text-sm text-red-500 mt-1">{validationErrors.name}</p>
+                              <p className="text-sm text-red-500 mt-1">
+                                {validationErrors.name}
+                              </p>
                             )}
                           </div>
                           <div className="grid grid-cols-2 gap-4">
@@ -538,42 +664,73 @@ export function HousesManagement({
                               <Select
                                 value={editingHouse.country}
                                 onValueChange={(value) => {
-                                  setEditingHouse({ ...editingHouse, country: value });
+                                  setEditingHouse({
+                                    ...editingHouse,
+                                    country: value,
+                                  });
                                   if (validationErrors.country) {
-                                    setValidationErrors({ ...validationErrors, country: '' });
+                                    setValidationErrors({
+                                      ...validationErrors,
+                                      country: "",
+                                    });
                                   }
                                 }}
                               >
-                                <SelectTrigger className={validationErrors.country ? 'border-red-500' : ''}>
+                                <SelectTrigger
+                                  className={
+                                    validationErrors.country
+                                      ? "border-red-500"
+                                      : ""
+                                  }
+                                >
                                   <SelectValue placeholder="Select a country" />
                                 </SelectTrigger>
                                 <SelectContent>
-                                  {countries.map(country => (
-                                    <SelectItem key={country} value={country}>{country}</SelectItem>
+                                  {countries.map((country) => (
+                                    <SelectItem key={country} value={country}>
+                                      {country}
+                                    </SelectItem>
                                   ))}
                                 </SelectContent>
                               </Select>
                               {validationErrors.country && (
-                                <p className="text-sm text-red-500 mt-1">{validationErrors.country}</p>
+                                <p className="text-sm text-red-500 mt-1">
+                                  {validationErrors.country}
+                                </p>
                               )}
                             </div>
                             <div>
-                              <Label htmlFor="edit-code">Code * (4 characters)</Label>
+                              <Label htmlFor="edit-code">
+                                Code * (4 characters)
+                              </Label>
                               <Input
                                 id="edit-code"
-                                value={editingHouse.code || ''}
+                                value={editingHouse.code || ""}
                                 onChange={(e) => {
-                                  const value = e.target.value.toUpperCase().slice(0, 4);
-                                  setEditingHouse({ ...editingHouse, code: value });
+                                  const value = e.target.value
+                                    .toUpperCase()
+                                    .slice(0, 4);
+                                  setEditingHouse({
+                                    ...editingHouse,
+                                    code: value,
+                                  });
                                   if (validationErrors.code) {
-                                    setValidationErrors({ ...validationErrors, code: '' });
+                                    setValidationErrors({
+                                      ...validationErrors,
+                                      code: "",
+                                    });
                                   }
                                 }}
                                 maxLength={4}
-                                className={validationErrors.code ? 'border-red-500' : ''}
+                                disabled={Boolean(editingHouse.code)}
+                                className={
+                                  validationErrors.code ? "border-red-500" : ""
+                                }
                               />
                               {validationErrors.code && (
-                                <p className="text-sm text-red-500 mt-1">{validationErrors.code}</p>
+                                <p className="text-sm text-red-500 mt-1">
+                                  {validationErrors.code}
+                                </p>
                               )}
                             </div>
                           </div>
@@ -584,35 +741,58 @@ export function HousesManagement({
                                 id="edit-city"
                                 value={editingHouse.city}
                                 onChange={(e) => {
-                                  setEditingHouse({ ...editingHouse, city: e.target.value });
+                                  setEditingHouse({
+                                    ...editingHouse,
+                                    city: e.target.value,
+                                  });
                                   if (validationErrors.city) {
-                                    setValidationErrors({ ...validationErrors, city: '' });
+                                    setValidationErrors({
+                                      ...validationErrors,
+                                      city: "",
+                                    });
                                   }
                                 }}
-                                className={validationErrors.city ? 'border-red-500' : ''}
+                                className={
+                                  validationErrors.city ? "border-red-500" : ""
+                                }
                               />
                               {validationErrors.city && (
-                                <p className="text-sm text-red-500 mt-1">{validationErrors.city}</p>
+                                <p className="text-sm text-red-500 mt-1">
+                                  {validationErrors.city}
+                                </p>
                               )}
                             </div>
                             <div>
                               <Label htmlFor="edit-postal">Postal Code</Label>
                               <Input
                                 id="edit-postal"
-                                value={editingHouse.postal_code || ''}
-                                onChange={(e) => setEditingHouse({ ...editingHouse, postal_code: e.target.value })}
+                                value={editingHouse.postal_code || ""}
+                                onChange={(e) =>
+                                  setEditingHouse({
+                                    ...editingHouse,
+                                    postal_code: e.target.value,
+                                  })
+                                }
                               />
                             </div>
                           </div>
                           <div>
-                            <Label htmlFor="edit-beneficiary">Beneficiary (comma separated)</Label>
+                            <Label htmlFor="edit-beneficiary">
+                              Beneficiary (comma separated)
+                            </Label>
                             <Input
                               id="edit-beneficiary"
-                              value={editingHouse.beneficiary ? editingHouse.beneficiary.join(', ') : ''}
+                              value={
+                                editingHouse.beneficiary
+                                  ? editingHouse.beneficiary.join(", ")
+                                  : ""
+                              }
                               onChange={(e) =>
                                 setEditingHouse({
                                   ...editingHouse,
-                                  beneficiary: e.target.value.split(',').map(b => b.trim())
+                                  beneficiary: e.target.value
+                                    .split(",")
+                                    .map((b) => b.trim()),
                                 })
                               }
                             />
@@ -622,11 +802,13 @@ export function HousesManagement({
                               <Label htmlFor="edit-latitude">Latitude</Label>
                               <Input
                                 id="edit-latitude"
-                                value={editingHouse.latitude ?? ''}
+                                value={editingHouse.latitude ?? ""}
                                 onChange={(e) =>
                                   setEditingHouse({
                                     ...editingHouse,
-                                    latitude: e.target.value ? parseFloat(e.target.value) : undefined
+                                    latitude: e.target.value
+                                      ? parseFloat(e.target.value)
+                                      : undefined,
                                   })
                                 }
                               />
@@ -635,61 +817,81 @@ export function HousesManagement({
                               <Label htmlFor="edit-longitude">Longitude</Label>
                               <Input
                                 id="edit-longitude"
-                                value={editingHouse.longitude ?? ''}
+                                value={editingHouse.longitude ?? ""}
                                 onChange={(e) =>
                                   setEditingHouse({
                                     ...editingHouse,
-                                    longitude: e.target.value ? parseFloat(e.target.value) : undefined
+                                    longitude: e.target.value
+                                      ? parseFloat(e.target.value)
+                                      : undefined,
                                   })
                                 }
                               />
                             </div>
                           </div>
                           <div>
-                            <Label htmlFor="edit-description">Description</Label>
+                            <Label htmlFor="edit-description">
+                              Description
+                            </Label>
                             <Input
                               id="edit-description"
-                              value={editingHouse.description || ''}
-                              onChange={(e) => setEditingHouse({ ...editingHouse, description: e.target.value })}
+                              value={editingHouse.description || ""}
+                              onChange={(e) =>
+                                setEditingHouse({
+                                  ...editingHouse,
+                                  description: e.target.value,
+                                })
+                              }
                             />
                           </div>
                           <div>
                             <Label htmlFor="edit-notes">Notes</Label>
                             <Input
                               id="edit-notes"
-                              value={editingHouse.notes || ''}
-                              onChange={(e) => setEditingHouse({ ...editingHouse, notes: e.target.value })}
+                              value={editingHouse.notes || ""}
+                              onChange={(e) =>
+                                setEditingHouse({
+                                  ...editingHouse,
+                                  notes: e.target.value,
+                                })
+                              }
                             />
                           </div>
                           <div>
                             <Label htmlFor="edit-address">Address</Label>
                             <Input
                               id="edit-address"
-                              value={editingHouse.address || ''}
-                              onChange={(e) => setEditingHouse({ ...editingHouse, address: e.target.value })}
-                            />
-                          </div>
-                          <div>
-                            <Label htmlFor="edit-year-built">Year Built</Label>
-                            <Input
-                              id="edit-year-built"
-                              value={editingHouse.yearBuilt ? editingHouse.yearBuilt.toString() : ''}
-                              onChange={(e) => setEditingHouse({ ...editingHouse, yearBuilt: e.target.value ? parseInt(e.target.value) : undefined })}
+                              value={editingHouse.address || ""}
+                              onChange={(e) =>
+                                setEditingHouse({
+                                  ...editingHouse,
+                                  address: e.target.value,
+                                })
+                              }
                             />
                           </div>
                           <div>
                             <Label>Icon</Label>
                             <IconSelector
                               selectedIcon={editingHouse.icon}
-                              onIconSelect={(icon) => setEditingHouse({ ...editingHouse, icon })}
+                              onIconSelect={(icon) =>
+                                setEditingHouse({ ...editingHouse, icon })
+                              }
                             />
                           </div>
                           <div className="flex justify-end gap-2">
-                            <Button variant="outline" onClick={() => {
-                              setEditingHouse(null);
-                              setValidationErrors({});
-                            }}>Cancel</Button>
-                            <Button onClick={handleEditHouse}>Save Changes</Button>
+                            <Button
+                              variant="outline"
+                              onClick={() => {
+                                setEditingHouse(null);
+                                setValidationErrors({});
+                              }}
+                            >
+                              Cancel
+                            </Button>
+                            <Button onClick={handleEditHouse}>
+                              Save Changes
+                            </Button>
                           </div>
                         </div>
                       )}
@@ -699,14 +901,18 @@ export function HousesManagement({
               </div>
             </CardHeader>
             <CardContent>
-              <Collapsible 
-                open={!collapsedHouses.has(house.id)} 
+              <Collapsible
+                open={!collapsedHouses.has(house.id)}
                 onOpenChange={() => toggleHouseCollapse(house.id)}
               >
                 <CollapsibleTrigger asChild>
-                  <Button variant="ghost" className="w-full justify-between p-0 h-auto">
+                  <Button
+                    variant="ghost"
+                    className="w-full justify-between p-0 h-auto"
+                  >
                     <h5 className="font-medium text-sm text-gray-700">
-                      Rooms ({house.rooms.filter(room => !room.is_deleted).length})
+                      Rooms (
+                      {house.rooms.filter((room) => !room.is_deleted).length})
                     </h5>
                     {collapsedHouses.has(house.id) ? (
                       <ChevronRight className="w-4 h-4" />
@@ -716,92 +922,115 @@ export function HousesManagement({
                   </Button>
                 </CollapsibleTrigger>
                 <CollapsibleContent className="space-y-2 mt-3">
-                  {house.rooms.filter(room => !room.is_deleted).map((room, roomIndex) => (
-                    <div 
-                      key={room.id} 
-                      className="flex items-center justify-between p-2 bg-gray-50 rounded cursor-move"
-                      draggable
-                      onDragStart={(e) => handleRoomDragStart(e, house.id, roomIndex)}
-                      onDragOver={handleDragOver}
-                      onDrop={(e) => handleRoomDrop(e, house.id, roomIndex)}
-                    >
-                      <div className="flex items-center gap-2">
-                        <GripVertical className="w-3 h-3 text-gray-400" />
-                        <span className="text-sm">{room.name}</span>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Switch
-                          checked={room.visible}
-                          onCheckedChange={() => onToggleRoom(house.id, room.id)}
-                        />
-                        {room.visible ? (
-                          <Eye className="w-3 h-3" />
-                        ) : (
-                          <EyeOff className="w-3 h-3" />
-                        )}
-                        <Dialog>
-                          <DialogTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => setEditingRoom({ houseId: house.id, room })}
-                            >
-                              <Edit className="w-3 h-3" />
-                            </Button>
-                          </DialogTrigger>
-                          <DialogContent>
-                            <DialogHeader>
-                              <DialogTitle>Edit Room</DialogTitle>
-                            </DialogHeader>
-                            {editingRoom && (
-                              <div className="space-y-4">
-                                <div>
-                                  <Label htmlFor="edit-room-name">Room Name</Label>
-                                  <Input
-                                    id="edit-room-name"
-                                    value={editingRoom.room.name}
-                                    onChange={(e) =>
-                                      setEditingRoom({
-                                        ...editingRoom,
-                                        room: { ...editingRoom.room, name: e.target.value }
-                                      })
-                                    }
-                                  />
+                  {house.rooms
+                    .filter((room) => !room.is_deleted)
+                    .map((room, roomIndex) => (
+                      <div
+                        key={room.id}
+                        className="flex items-center justify-between p-2 bg-gray-50 rounded cursor-move"
+                        draggable
+                        onDragStart={(e) =>
+                          handleRoomDragStart(e, house.id, roomIndex)
+                        }
+                        onDragOver={handleDragOver}
+                        onDrop={(e) => handleRoomDrop(e, house.id, roomIndex)}
+                      >
+                        <div className="flex items-center gap-2">
+                          <GripVertical className="w-3 h-3 text-gray-400" />
+                          <span className="text-sm">{room.name}</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Switch
+                            checked={room.visible}
+                            onCheckedChange={() =>
+                              onToggleRoom(house.id, room.id)
+                            }
+                          />
+                          {room.visible ? (
+                            <Eye className="w-3 h-3" />
+                          ) : (
+                            <EyeOff className="w-3 h-3" />
+                          )}
+                          <Dialog>
+                            <DialogTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() =>
+                                  setEditingRoom({ houseId: house.id, room })
+                                }
+                              >
+                                <Edit className="w-3 h-3" />
+                              </Button>
+                            </DialogTrigger>
+                            <DialogContent>
+                              <DialogHeader>
+                                <DialogTitle>Edit Room</DialogTitle>
+                              </DialogHeader>
+                              {editingRoom && (
+                                <div className="space-y-4">
+                                  <div>
+                                    <Label htmlFor="edit-room-name">
+                                      Room Name
+                                    </Label>
+                                    <Input
+                                      id="edit-room-name"
+                                      value={editingRoom.room.name}
+                                      onChange={(e) =>
+                                        setEditingRoom({
+                                          ...editingRoom,
+                                          room: {
+                                            ...editingRoom.room,
+                                            name: e.target.value,
+                                          },
+                                        })
+                                      }
+                                    />
+                                  </div>
+                                  <div className="flex justify-end gap-2">
+                                    <Button
+                                      variant="outline"
+                                      onClick={() => setEditingRoom(null)}
+                                    >
+                                      Cancel
+                                    </Button>
+                                    <Button onClick={handleEditRoom}>
+                                      Save Changes
+                                    </Button>
+                                  </div>
                                 </div>
-                                <div className="flex justify-end gap-2">
-                                  <Button variant="outline" onClick={() => setEditingRoom(null)}>
-                                    Cancel
-                                  </Button>
-                                  <Button onClick={handleEditRoom}>Save Changes</Button>
-                                </div>
-                              </div>
-                            )}
-                          </DialogContent>
-                        </Dialog>
-                        <AlertDialog>
-                          <AlertDialogTrigger asChild>
-                            <Button variant="ghost" size="sm">
-                              <Trash2 className="w-3 h-3" />
-                            </Button>
-                          </AlertDialogTrigger>
-                          <AlertDialogContent>
-                            <AlertDialogHeader>
-                              <AlertDialogTitle>Delete Room</AlertDialogTitle>
-                              <AlertDialogDescription>
-                                Are you sure you want to delete "{room.name}"? This action cannot be undone.
-                              </AlertDialogDescription>
-                            </AlertDialogHeader>
-                            <AlertDialogFooter>
-                              <AlertDialogCancel>Cancel</AlertDialogCancel>
-                              <AlertDialogAction onClick={() => onDeleteRoom(house.id, room.id)}>
-                                Delete
-                              </AlertDialogAction>
-                            </AlertDialogFooter>
-                          </AlertDialogContent>
-                        </AlertDialog>
+                              )}
+                            </DialogContent>
+                          </Dialog>
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <Button variant="ghost" size="sm">
+                                <Trash2 className="w-3 h-3" />
+                              </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>Delete Room</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  Are you sure you want to delete "{room.name}"?
+                                  This action cannot be undone.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+                              <AlertDialogFooter>
+                                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                                <AlertDialogAction
+                                  onClick={() =>
+                                    onDeleteRoom(house.id, room.id)
+                                  }
+                                >
+                                  Delete
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
+                        </div>
                       </div>
-                    </div>
-                  ))}
+                    ))}
                 </CollapsibleContent>
               </Collapsible>
             </CardContent>

--- a/src/hooks/useSettingsState.ts
+++ b/src/hooks/useSettingsState.ts
@@ -1,14 +1,19 @@
-
 import { useState, useEffect } from "react";
-import { categoryConfigs, defaultHouses, CategoryConfig, HouseConfig, RoomConfig } from "@/types/inventory";
+import {
+  categoryConfigs,
+  defaultHouses,
+  CategoryConfig,
+  HouseConfig,
+  RoomConfig,
+} from "@/types/inventory";
 
 // Load persisted settings from localStorage if available
 let storedCategories: CategoryConfig[] | null = null;
 let storedHouses: HouseConfig[] | null = null;
-if (typeof window !== 'undefined') {
+if (typeof window !== "undefined") {
   try {
-    storedCategories = JSON.parse(localStorage.getItem('categories') || 'null');
-    storedHouses = JSON.parse(localStorage.getItem('houses') || 'null');
+    storedCategories = JSON.parse(localStorage.getItem("categories") || "null");
+    storedHouses = JSON.parse(localStorage.getItem("houses") || "null");
   } catch {
     storedCategories = null;
     storedHouses = null;
@@ -21,14 +26,14 @@ let globalHouses: HouseConfig[] = storedHouses || defaultHouses;
 let listeners: (() => void)[] = [];
 
 const notifyListeners = () => {
-  listeners.forEach(listener => listener());
+  listeners.forEach((listener) => listener());
 };
 
 const saveState = () => {
-  if (typeof window !== 'undefined') {
+  if (typeof window !== "undefined") {
     try {
-      localStorage.setItem('categories', JSON.stringify(globalCategories));
-      localStorage.setItem('houses', JSON.stringify(globalHouses));
+      localStorage.setItem("categories", JSON.stringify(globalCategories));
+      localStorage.setItem("houses", JSON.stringify(globalHouses));
     } catch {
       // Ignore write errors (e.g., storage quota)
     }
@@ -36,7 +41,8 @@ const saveState = () => {
 };
 
 export function useSettingsState() {
-  const [categories, setCategories] = useState<CategoryConfig[]>(globalCategories);
+  const [categories, setCategories] =
+    useState<CategoryConfig[]>(globalCategories);
   const [houses, setHouses] = useState<HouseConfig[]>(globalHouses);
   const [, forceUpdate] = useState({});
 
@@ -46,21 +52,21 @@ export function useSettingsState() {
       setHouses([...globalHouses]);
       forceUpdate({});
     };
-    
+
     listeners.push(listener);
-    
+
     return () => {
-      listeners = listeners.filter(l => l !== listener);
+      listeners = listeners.filter((l) => l !== listener);
     };
   }, []);
 
   const addCategory = (name: string, icon: string) => {
     const newCategory: CategoryConfig = {
-      id: name.toLowerCase().replace(/\s+/g, '-'),
+      id: name.toLowerCase().replace(/\s+/g, "-"),
       name,
       icon,
       subcategories: [],
-      visible: true
+      visible: true,
     };
     globalCategories = [...globalCategories, newCategory];
     saveState();
@@ -68,7 +74,7 @@ export function useSettingsState() {
     return newCategory;
   };
 
-  const addHouse = (house: Omit<HouseConfig, 'id' | 'rooms'>) => {
+  const addHouse = (house: Omit<HouseConfig, "id" | "rooms">) => {
     const newHouse: HouseConfig = {
       ...house,
       id: Date.now().toString(),
@@ -82,9 +88,11 @@ export function useSettingsState() {
   };
 
   const editHouse = (houseId: string, updates: Partial<HouseConfig>) => {
-    globalHouses = globalHouses.map(house => {
+    globalHouses = globalHouses.map((house) => {
       if (house.id === houseId) {
-        const history = house.history ? [...house.history, { ...house }] : [{ ...house }];
+        const history = house.history
+          ? [...house.history, { ...house }]
+          : [{ ...house }];
         return {
           ...house,
           ...updates,
@@ -98,8 +106,11 @@ export function useSettingsState() {
     notifyListeners();
   };
 
-  const addRoom = (houseId: string, room: Partial<RoomConfig> & { name: string; floor: number }) => {
-    globalHouses = globalHouses.map(house => {
+  const addRoom = (
+    houseId: string,
+    room: Partial<RoomConfig> & { name: string; floor: number },
+  ) => {
+    globalHouses = globalHouses.map((house) => {
       if (house.id === houseId) {
         const newRoom: RoomConfig = {
           id: Date.now().toString(),
@@ -119,7 +130,7 @@ export function useSettingsState() {
         };
         return {
           ...house,
-          rooms: [...house.rooms, newRoom]
+          rooms: [...house.rooms, newRoom],
         };
       }
       return house;
@@ -128,14 +139,20 @@ export function useSettingsState() {
     notifyListeners();
   };
 
-  const editRoom = (houseId: string, roomId: string, updates: Partial<RoomConfig>) => {
-    globalHouses = globalHouses.map(house => {
+  const editRoom = (
+    houseId: string,
+    roomId: string,
+    updates: Partial<RoomConfig>,
+  ) => {
+    globalHouses = globalHouses.map((house) => {
       if (house.id === houseId) {
         return {
           ...house,
-          rooms: house.rooms.map(room => {
+          rooms: house.rooms.map((room) => {
             if (room.id === roomId) {
-              const history = room.history ? [...room.history, { ...room }] : [{ ...room }];
+              const history = room.history
+                ? [...room.history, { ...room }]
+                : [{ ...room }];
               return {
                 ...room,
                 ...updates,
@@ -144,7 +161,7 @@ export function useSettingsState() {
               };
             }
             return room;
-          })
+          }),
         };
       }
       return house;
@@ -154,11 +171,11 @@ export function useSettingsState() {
   };
 
   const deleteRoom = (houseId: string, roomId: string) => {
-    globalHouses = globalHouses.map(house => {
+    globalHouses = globalHouses.map((house) => {
       if (house.id === houseId) {
         return {
           ...house,
-          rooms: house.rooms.filter(room => room.id !== roomId)
+          rooms: house.rooms.filter((room) => room.id !== roomId),
         };
       }
       return house;
@@ -177,7 +194,7 @@ export function useSettingsState() {
   };
 
   const moveRoom = (houseId: string, from: number, to: number) => {
-    globalHouses = globalHouses.map(h => {
+    globalHouses = globalHouses.map((h) => {
       if (h.id === houseId) {
         const rooms = Array.from(h.rooms);
         const [moved] = rooms.splice(from, 1);
@@ -191,16 +208,16 @@ export function useSettingsState() {
   };
 
   const addSubcategory = (categoryId: string, subcategoryName: string) => {
-    globalCategories = globalCategories.map(category => {
+    globalCategories = globalCategories.map((category) => {
       if (category.id === categoryId) {
         const newSubcategory = {
-          id: subcategoryName.toLowerCase().replace(/\s+/g, '-'),
+          id: subcategoryName.toLowerCase().replace(/\s+/g, "-"),
           name: subcategoryName,
-          visible: true
+          visible: true,
         };
         return {
           ...category,
-          subcategories: [...category.subcategories, newSubcategory]
+          subcategories: [...category.subcategories, newSubcategory],
         };
       }
       return category;
@@ -210,11 +227,13 @@ export function useSettingsState() {
   };
 
   const deleteSubcategory = (categoryId: string, subcategoryId: string) => {
-    globalCategories = globalCategories.map(category => {
+    globalCategories = globalCategories.map((category) => {
       if (category.id === categoryId) {
         return {
           ...category,
-          subcategories: category.subcategories.filter(sub => sub.id !== subcategoryId)
+          subcategories: category.subcategories.filter(
+            (sub) => sub.id !== subcategoryId,
+          ),
         };
       }
       return category;
@@ -233,7 +252,7 @@ export function useSettingsState() {
   };
 
   const moveSubcategory = (categoryId: string, from: number, to: number) => {
-    globalCategories = globalCategories.map(cat => {
+    globalCategories = globalCategories.map((cat) => {
       if (cat.id === categoryId) {
         const subs = Array.from(cat.subcategories);
         const [moved] = subs.splice(from, 1);
@@ -247,21 +266,21 @@ export function useSettingsState() {
   };
 
   const toggleHouseVisibility = (houseId: string) => {
-    globalHouses = globalHouses.map(h =>
-      h.id === houseId ? { ...h, visible: !h.visible } : h
+    globalHouses = globalHouses.map((h) =>
+      h.id === houseId ? { ...h, visible: !h.visible } : h,
     );
     saveState();
     notifyListeners();
   };
 
   const toggleRoomVisibility = (houseId: string, roomId: string) => {
-    globalHouses = globalHouses.map(h => {
+    globalHouses = globalHouses.map((h) => {
       if (h.id === houseId) {
         return {
           ...h,
-          rooms: h.rooms.map(r =>
-            r.id === roomId ? { ...r, visible: !r.visible } : r
-          )
+          rooms: h.rooms.map((r) =>
+            r.id === roomId ? { ...r, visible: !r.visible } : r,
+          ),
         };
       }
       return h;
@@ -271,8 +290,8 @@ export function useSettingsState() {
   };
 
   const toggleCategoryVisibility = (categoryId: string) => {
-    globalCategories = globalCategories.map(c =>
-      c.id === categoryId ? { ...c, visible: !c.visible } : c
+    globalCategories = globalCategories.map((c) =>
+      c.id === categoryId ? { ...c, visible: !c.visible } : c,
     );
     saveState();
     notifyListeners();
@@ -280,15 +299,15 @@ export function useSettingsState() {
 
   const toggleSubcategoryVisibility = (
     categoryId: string,
-    subcategoryId: string
+    subcategoryId: string,
   ) => {
-    globalCategories = globalCategories.map(c => {
+    globalCategories = globalCategories.map((c) => {
       if (c.id === categoryId) {
         return {
           ...c,
-          subcategories: c.subcategories.map(s =>
-            s.id === subcategoryId ? { ...s, visible: !s.visible } : s
-          )
+          subcategories: c.subcategories.map((s) =>
+            s.id === subcategoryId ? { ...s, visible: !s.visible } : s,
+          ),
         };
       }
       return c;
@@ -299,32 +318,32 @@ export function useSettingsState() {
 
   const downloadMappings = () => {
     const mappings = {
-      houses: houses.map(h => ({
+      houses: houses.map((h) => ({
         id: h.id,
         name: h.name,
         country: h.country,
         address: h.address,
-        yearBuilt: h.yearBuilt,
         code: h.code,
         icon: h.icon,
-        rooms: h.rooms.map(r => ({ id: r.id, name: r.name }))
+        rooms: h.rooms.map((r) => ({ id: r.id, name: r.name })),
       })),
-      categories: categories.map(c => ({
+      categories: categories.map((c) => ({
         id: c.id,
         name: c.name,
         icon: c.icon,
-        subcategories: c.subcategories.map(s => ({ id: s.id, name: s.name }))
-      }))
+        subcategories: c.subcategories.map((s) => ({ id: s.id, name: s.name })),
+      })),
     };
 
     const dataStr = JSON.stringify(mappings, null, 2);
-    const dataUri = 'data:application/json;charset=utf-8,' + encodeURIComponent(dataStr);
-    
-    const exportFileDefaultName = 'inventory-mappings.json';
-    
-    const linkElement = document.createElement('a');
-    linkElement.setAttribute('href', dataUri);
-    linkElement.setAttribute('download', exportFileDefaultName);
+    const dataUri =
+      "data:application/json;charset=utf-8," + encodeURIComponent(dataStr);
+
+    const exportFileDefaultName = "inventory-mappings.json";
+
+    const linkElement = document.createElement("a");
+    linkElement.setAttribute("href", dataUri);
+    linkElement.setAttribute("download", exportFileDefaultName);
     linkElement.click();
   };
 
@@ -347,6 +366,6 @@ export function useSettingsState() {
     toggleHouseVisibility,
     toggleRoomVisibility,
     toggleCategoryVisibility,
-    toggleSubcategoryVisibility
+    toggleSubcategoryVisibility,
   };
 }

--- a/src/types/inventory.ts
+++ b/src/types/inventory.ts
@@ -1,4 +1,3 @@
-
 export interface ItemBase {
   id: number;
   title: string;
@@ -68,11 +67,18 @@ export interface MusicItem extends ItemBase {
 
 export type InventoryItem = DecorItem | BookItem | MusicItem;
 
-
 export type ViewMode = "grid" | "list" | "table";
 export type CategoryFilter = "all" | string;
 export type HouseFilter = "all" | "main-house" | "guest-house" | "studio";
-export type RoomFilter = "all" | "living-room" | "bedroom" | "kitchen" | "dining-room" | "office" | "bathroom" | "hallway";
+export type RoomFilter =
+  | "all"
+  | "living-room"
+  | "bedroom"
+  | "kitchen"
+  | "dining-room"
+  | "office"
+  | "bathroom"
+  | "hallway";
 
 // Configuration types for settings
 export interface CategoryConfig {
@@ -102,7 +108,6 @@ export interface HouseConfig {
   longitude?: number;
   description?: string;
   notes?: string;
-  yearBuilt?: number;
   icon: string;
   rooms: RoomConfig[];
   visible: boolean;
@@ -139,9 +144,9 @@ export const categoryConfigs: CategoryConfig[] = [
       { id: "painting", name: "Painting", visible: true },
       { id: "sculpture", name: "Sculpture", visible: true },
       { id: "photography", name: "Photography", visible: true },
-      { id: "print", name: "Print", visible: true }
+      { id: "print", name: "Print", visible: true },
     ],
-    visible: true
+    visible: true,
   },
   {
     id: "furniture",
@@ -152,9 +157,9 @@ export const categoryConfigs: CategoryConfig[] = [
       { id: "table", name: "Table", visible: true },
       { id: "sofa", name: "Sofa", visible: true },
       { id: "cabinet", name: "Cabinet", visible: true },
-      { id: "rug", name: "Rug", visible: true }
+      { id: "rug", name: "Rug", visible: true },
     ],
-    visible: true
+    visible: true,
   },
   {
     id: "decorative",
@@ -163,10 +168,10 @@ export const categoryConfigs: CategoryConfig[] = [
     subcategories: [
       { id: "vase", name: "Vase", visible: true },
       { id: "mirror", name: "Mirror", visible: true },
-      { id: "lighting", name: "Lighting", visible: true }
+      { id: "lighting", name: "Lighting", visible: true },
     ],
-    visible: true
-  }
+    visible: true,
+  },
 ];
 
 // House configurations with icons
@@ -184,20 +189,68 @@ export const defaultHouses: HouseConfig[] = [
     longitude: -118.4004,
     description: "Primary residence",
     notes: "",
-    yearBuilt: 1985,
     version: 1,
     is_deleted: false,
     icon: "house",
     rooms: [
-      { id: "living-room", name: "Living Room", floor: 1, version: 1, is_deleted: false, visible: true },
-      { id: "dining-room", name: "Dining Room", floor: 1, version: 1, is_deleted: false, visible: true },
-      { id: "kitchen", name: "Kitchen", floor: 1, version: 1, is_deleted: false, visible: true },
-      { id: "bedroom", name: "Bedroom", floor: 2, version: 1, is_deleted: false, visible: true },
-      { id: "office", name: "Office", floor: 2, version: 1, is_deleted: false, visible: true },
-      { id: "bathroom", name: "Bathroom", floor: 2, version: 1, is_deleted: false, visible: true },
-      { id: "hallway", name: "Hallway", floor: 1, version: 1, is_deleted: false, visible: true }
+      {
+        id: "living-room",
+        name: "Living Room",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "dining-room",
+        name: "Dining Room",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "kitchen",
+        name: "Kitchen",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "bedroom",
+        name: "Bedroom",
+        floor: 2,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "office",
+        name: "Office",
+        floor: 2,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "bathroom",
+        name: "Bathroom",
+        floor: 2,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "hallway",
+        name: "Hallway",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
     ],
-    visible: true
+    visible: true,
   },
   {
     id: "guest-house",
@@ -212,17 +265,44 @@ export const defaultHouses: HouseConfig[] = [
     longitude: -118.4004,
     description: "Guest accommodation",
     notes: "",
-    yearBuilt: 1990,
     version: 1,
     is_deleted: false,
     icon: "house",
     rooms: [
-      { id: "living-room", name: "Living Room", floor: 1, version: 1, is_deleted: false, visible: true },
-      { id: "bedroom", name: "Bedroom", floor: 1, version: 1, is_deleted: false, visible: true },
-      { id: "kitchen", name: "Kitchen", floor: 1, version: 1, is_deleted: false, visible: true },
-      { id: "bathroom", name: "Bathroom", floor: 1, version: 1, is_deleted: false, visible: true }
+      {
+        id: "living-room",
+        name: "Living Room",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "bedroom",
+        name: "Bedroom",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "kitchen",
+        name: "Kitchen",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "bathroom",
+        name: "Bathroom",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
     ],
-    visible: true
+    visible: true,
   },
   {
     id: "studio",
@@ -237,14 +317,27 @@ export const defaultHouses: HouseConfig[] = [
     longitude: 2.3601,
     description: "Work studio",
     notes: "",
-    yearBuilt: 2010,
     version: 1,
     is_deleted: false,
     icon: "house",
     rooms: [
-      { id: "main-area", name: "Main Area", floor: 1, version: 1, is_deleted: false, visible: true },
-      { id: "storage", name: "Storage", floor: 1, version: 1, is_deleted: false, visible: true }
+      {
+        id: "main-area",
+        name: "Main Area",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "storage",
+        name: "Storage",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
     ],
-    visible: true
-  }
+    visible: true,
+  },
 ];


### PR DESCRIPTION
## Summary
- drop `yearBuilt` from `HouseConfig` and example houses
- remove year built fields from House management forms
- disable editing house code once set
- update settings export to exclude year built

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687029c64628832594b1e6beae2478d6