### PR TITLE
Improve house editing UX

### DIFF
--- a/src/components/settings/HousesManagement.tsx
+++ b/src/components/settings/HousesManagement.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
@@ -78,6 +79,7 @@ export function HousesManagement({
   onToggleHouse,
   onToggleRoom,
 }: HousesManagementProps) {
+  const { toast } = useToast();
   const [newHouse, setNewHouse] = useState({
     name: "",
     code: "",
@@ -172,6 +174,11 @@ export function HousesManagement({
     const errors = validateHouse(newHouse);
     if (Object.keys(errors).length > 0) {
       setValidationErrors(errors);
+      toast({
+        title: "Missing required fields",
+        description: "Please fill in all mandatory fields",
+        variant: "destructive",
+      });
       return;
     }
 
@@ -220,6 +227,11 @@ export function HousesManagement({
     const errors = validateRoom(newRoom);
     if (Object.keys(errors).length > 0) {
       setValidationErrors(errors);
+      toast({
+        title: "Missing required fields",
+        description: "Please fill in all mandatory fields",
+        variant: "destructive",
+      });
       return;
     }
     onAddRoom(newRoom.houseId, {
@@ -290,6 +302,11 @@ export function HousesManagement({
 
     if (Object.keys(errors).length > 0) {
       setValidationErrors(errors);
+      toast({
+        title: "Missing required fields",
+        description: "Please fill in all mandatory fields",
+        variant: "destructive",
+      });
       return;
     }
 
@@ -307,6 +324,10 @@ export function HousesManagement({
       notes: editingHouse.notes,
       yearBuilt: editingHouse.yearBuilt,
       icon: editingHouse.icon,
+    });
+    toast({
+      title: "House updated",
+      description: "Changes saved successfully",
     });
     setValidationErrors({});
     setEditingHouse(null);
@@ -804,15 +825,15 @@ export function HousesManagement({
             <CardHeader className="pb-3">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3 flex-1">
-                  <GripVertical className="w-4 h-4 text-gray-400" />
+                  <GripVertical className="w-4 h-4 text-gray-400 dark:text-gray-500" />
                   <div className="flex-1">
                     <div className="flex items-center gap-2">
                       <CardTitle className="text-lg">{house.name}</CardTitle>
-                      <span className="text-sm font-mono bg-gray-100 px-2 py-1 rounded">
+                      <span className="text-sm font-mono bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">
                         {house.code}
                       </span>
                     </div>
-                    <div className="text-sm text-gray-600 mt-1">
+                    <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
                       {house.address ? `${house.address.split(",")[0]}, ` : ""}
                       {house.country}
                     </div>
@@ -1136,7 +1157,7 @@ export function HousesManagement({
                     variant="ghost"
                     className="w-full justify-between p-0 h-auto"
                   >
-                    <h5 className="font-medium text-sm text-gray-700">
+                    <h5 className="font-medium text-sm text-gray-700 dark:text-gray-300">
                       Rooms (
                       {house.rooms.filter((room) => !room.is_deleted).length})
                     </h5>
@@ -1153,7 +1174,7 @@ export function HousesManagement({
                     .map((room, roomIndex) => (
                       <div
                         key={room.id}
-                        className="flex items-center justify-between p-2 bg-gray-50 rounded cursor-move"
+                        className="flex items-center justify-between p-2 bg-gray-50 dark:bg-gray-800 rounded cursor-move"
                         draggable
                         onDragStart={(e) =>
                           handleRoomDragStart(e, house.id, roomIndex)
@@ -1162,7 +1183,7 @@ export function HousesManagement({
                         onDrop={(e) => handleRoomDrop(e, house.id, roomIndex)}
                       >
                         <div className="flex items-center gap-2">
-                          <GripVertical className="w-3 h-3 text-gray-400" />
+                          <GripVertical className="w-3 h-3 text-gray-400 dark:text-gray-500" />
                           <span className="text-sm">{room.name}</span>
                         </div>
                         <div className="flex items-center gap-2">
@@ -1389,7 +1410,7 @@ export function HousesManagement({
                                         value={editingRoom.room.code || ""}
                                         disabled
                                       />
-                                      <p className="text-xs text-gray-500 mt-1">
+                                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                                         Code is auto-generated from the house
                                         code.
                                       </p>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,16 +1,16 @@
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Dialog = DialogPrimitive.Root
+const Dialog = DialogPrimitive.Root;
 
-const DialogTrigger = DialogPrimitive.Trigger
+const DialogTrigger = DialogPrimitive.Trigger;
 
-const DialogPortal = DialogPrimitive.Portal
+const DialogPortal = DialogPrimitive.Portal;
 
-const DialogClose = DialogPrimitive.Close
+const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -19,13 +19,13 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
+      "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
     )}
     {...props}
   />
-))
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
+        className,
       )}
       {...props}
     >
@@ -48,8 +48,8 @@ const DialogContent = React.forwardRef<
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
-))
-DialogContent.displayName = DialogPrimitive.Content.displayName
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({
   className,
@@ -58,12 +58,12 @@ const DialogHeader = ({
   <div
     className={cn(
       "flex flex-col space-y-1.5 text-center sm:text-left",
-      className
+      className,
     )}
     {...props}
   />
-)
-DialogHeader.displayName = "DialogHeader"
+);
+DialogHeader.displayName = "DialogHeader";
 
 const DialogFooter = ({
   className,
@@ -72,12 +72,12 @@ const DialogFooter = ({
   <div
     className={cn(
       "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
+      className,
     )}
     {...props}
   />
-)
-DialogFooter.displayName = "DialogFooter"
+);
+DialogFooter.displayName = "DialogFooter";
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
@@ -87,12 +87,12 @@ const DialogTitle = React.forwardRef<
     ref={ref}
     className={cn(
       "text-lg font-semibold leading-none tracking-tight",
-      className
+      className,
     )}
     {...props}
   />
-))
-DialogTitle.displayName = DialogPrimitive.Title.displayName
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
 const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
@@ -103,8 +103,8 @@ const DialogDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
-DialogDescription.displayName = DialogPrimitive.Description.displayName
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
   Dialog,
@@ -117,4 +117,4 @@ export {
   DialogFooter,
   DialogTitle,
   DialogDescription,
-}
+};


### PR DESCRIPTION
## Summary
- warn about missing fields when editing houses
- show toast on successful house edit
- tweak dialog overlay style
- adjust house/room settings for dark mode

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687041a821e08325a38d7050afa352a7