### PR TITLE
Fix editCategory reference

### DIFF
--- a/src/components/SettingsManagement.tsx
+++ b/src/components/SettingsManagement.tsx
@@ -27,6 +27,8 @@ export function SettingsManagement() {
     moveRoom,
     moveCategory,
     moveSubcategory,
+    editCategory,
+    editSubcategory,
     toggleHouseVisibility,
     toggleRoomVisibility,
     toggleCategoryVisibility,


### PR DESCRIPTION
## Summary
- include `editCategory` and `editSubcategory` when pulling from `useSettingsState`

## Testing
- `npm run dev` *(server started and was stopped)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68714ab9c5a48325883750067df3ffbb