### PR TITLE
Improve download menu with CSV/JSON options

### DIFF
--- a/src/components/InventoryHeader.tsx
+++ b/src/components/InventoryHeader.tsx
@@ -1,5 +1,10 @@
-
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Plus, Download, Images } from "lucide-react";
 import { DarkModeToggle } from "@/components/DarkModeToggle";
 import { useNavigate } from "react-router-dom";
@@ -12,9 +17,22 @@ export function InventoryHeader() {
 
   const downloadCSV = async () => {
     const headers = [
-      'ID', 'Title', 'Artist', 'Category', 'Subcategory', 'Width (cm)', 'Height (cm)', 'Depth (cm)', 'Valuation',
-      'Valuation Currency', 'Quantity', 'Year/Period', 'Description',
-      'House', 'Room', 'Notes'
+      "ID",
+      "Title",
+      "Artist",
+      "Category",
+      "Subcategory",
+      "Width (cm)",
+      "Height (cm)",
+      "Depth (cm)",
+      "Valuation",
+      "Valuation Currency",
+      "Quantity",
+      "Year/Period",
+      "Description",
+      "House",
+      "Room",
+      "Notes",
     ];
 
     // Use sample items as fallback if API fails
@@ -23,38 +41,70 @@ export function InventoryHeader() {
       const { fetchDecorItems } = await import("@/lib/api");
       items = await fetchDecorItems();
     } catch (err) {
-      console.error('Failed to fetch items for CSV, using sample data:', err);
+      console.error("Failed to fetch items for CSV, using sample data:", err);
     }
 
     const csvContent = [
-      headers.join(','),
-      ...items.map(item => [
-        item.id || '',
-        `"${item.title || ''}"`,
-        `"${item.artist || ''}"`,
-        `"${item.category || ''}"`,
-        `"${item.subcategory || ''}"`,
-        item.widthCm ?? '',
-        item.heightCm ?? '',
-        item.depthCm ?? '',
-        item.valuation || '',
-        `"${item.valuationCurrency || ''}"`,
-        item.quantity || '',
-        `"${item.yearPeriod || ''}"`,
-        `"${item.description || ''}"`,
-        `"${item.house || ''}"`,
-        `"${item.room || ''}"`,
-        `"${item.notes || ''}"`
-      ].join(','))
-    ].join('\n');
+      headers.join(","),
+      ...items.map((item) =>
+        [
+          item.id || "",
+          `"${item.title || ""}"`,
+          `"${item.artist || ""}"`,
+          `"${item.category || ""}"`,
+          `"${item.subcategory || ""}"`,
+          item.widthCm ?? "",
+          item.heightCm ?? "",
+          item.depthCm ?? "",
+          item.valuation || "",
+          `"${item.valuationCurrency || ""}"`,
+          item.quantity || "",
+          `"${item.yearPeriod || ""}"`,
+          `"${item.description || ""}"`,
+          `"${item.house || ""}"`,
+          `"${item.room || ""}"`,
+          `"${item.notes || ""}"`,
+        ].join(","),
+      ),
+    ].join("\n");
 
     // Create and download the CSV file
-    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-    const link = document.createElement('a');
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const link = document.createElement("a");
     const url = URL.createObjectURL(blob);
-    link.setAttribute('href', url);
-    link.setAttribute('download', `inventory_${new Date().toISOString().split('T')[0]}.csv`);
-    link.style.visibility = 'hidden';
+    link.setAttribute("href", url);
+    link.setAttribute(
+      "download",
+      `inventory_${new Date().toISOString().split("T")[0]}.csv`,
+    );
+    link.style.visibility = "hidden";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const downloadJSON = async () => {
+    let items = sampleDecorItems;
+    try {
+      const { fetchDecorItems } = await import("@/lib/api");
+      items = await fetchDecorItems();
+    } catch (err) {
+      console.error("Failed to fetch items for JSON, using sample data:", err);
+    }
+
+    const jsonContent = JSON.stringify(items, null, 2);
+    const blob = new Blob([jsonContent], {
+      type: "application/json;charset=utf-8;",
+    });
+    const link = document.createElement("a");
+    const url = URL.createObjectURL(blob);
+    link.setAttribute("href", url);
+    link.setAttribute(
+      "download",
+      `inventory_${new Date().toISOString().split("T")[0]}.json`,
+    );
+    link.style.visibility = "hidden";
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -64,8 +114,8 @@ export function InventoryHeader() {
   const downloadImages = async () => {
     // This is a simplified version - in a real app you'd need a backend service
     // to create and serve the zip file with all images
-    console.log('Downloading images zip...');
-    alert('Image download functionality requires backend implementation');
+    console.log("Downloading images zip...");
+    alert("Image download functionality requires backend implementation");
   };
 
   return (
@@ -76,27 +126,36 @@ export function InventoryHeader() {
             Collection Manager
           </h1>
         </div>
-        
+
         <div className="flex items-center gap-3">
           {/* Show download buttons on inventory, category and house pages */}
-          {(location.pathname === '/inventory' ||
-            location.pathname === '/' ||
-            location.pathname.startsWith('/category/') ||
-            location.pathname.startsWith('/house/')) && (
-            <>
-              <Button variant="outline" onClick={downloadCSV}>
-                <Download className="w-4 h-4 mr-2" />
-                Full CSV
-              </Button>
-              <Button variant="outline" onClick={downloadImages}>
-                <Images className="w-4 h-4 mr-2" />
-                Full Images
-              </Button>
-            </>
+          {(location.pathname === "/inventory" ||
+            location.pathname === "/" ||
+            location.pathname.startsWith("/category/") ||
+            location.pathname.startsWith("/house/")) && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline">
+                  <Download className="w-4 h-4 mr-2" />
+                  Download
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem onClick={downloadCSV}>
+                  All Items (CSV)
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={downloadJSON}>
+                  All Items (JSON)
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={downloadImages}>
+                  All Images
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
 
-          {location.pathname !== '/add' && (
-            <Button onClick={() => navigate('/add')}>
+          {location.pathname !== "/add" && (
+            <Button onClick={() => navigate("/add")}>
               <Plus className="w-4 h-4 mr-2" />
               Add Item
             </Button>

--- a/src/components/SearchFilters.tsx
+++ b/src/components/SearchFilters.tsx
@@ -1,4 +1,3 @@
-
 import { ViewMode } from "@/types/inventory";
 import { FilterHeader } from "@/components/filters/FilterHeader";
 import { SearchInput } from "@/components/filters/SearchInput";
@@ -32,6 +31,7 @@ interface SearchFiltersProps {
   viewMode: ViewMode;
   setViewMode: (mode: ViewMode) => void;
   onDownloadCSV?: () => void;
+  onDownloadJSON?: () => void;
   onDownloadImages?: () => void;
   permanentCategory?: string;
   permanentHouse?: string;
@@ -59,6 +59,7 @@ export function SearchFilters({
   viewMode,
   setViewMode,
   onDownloadCSV,
+  onDownloadJSON,
   onDownloadImages,
   permanentCategory,
   permanentHouse,
@@ -80,6 +81,7 @@ export function SearchFilters({
         viewMode={viewMode}
         setViewMode={setViewMode}
         onDownloadCSV={onDownloadCSV}
+        onDownloadJSON={onDownloadJSON}
         onDownloadImages={onDownloadImages}
       />
 
@@ -87,11 +89,13 @@ export function SearchFilters({
       <div
         className={cn(
           "bg-card p-4 rounded-lg border shadow-sm relative",
-          activeCount > 0 && "border-primary"
+          activeCount > 0 && "border-primary",
         )}
       >
         {activeCount > 0 && (
-          <span className="absolute top-2 right-2 text-xs font-semibold">{activeCount}</span>
+          <span className="absolute top-2 right-2 text-xs font-semibold">
+            {activeCount}
+          </span>
         )}
         <div className="grid grid-cols-1 md:grid-cols-6 gap-6 items-end">
           {/* Search - spans 2 columns */}
@@ -137,7 +141,6 @@ export function SearchFilters({
               setRange={setValuationRange}
             />
           </div>
-
         </div>
       </div>
 

--- a/src/components/filters/FilterHeader.tsx
+++ b/src/components/filters/FilterHeader.tsx
@@ -1,12 +1,18 @@
-
 import { Grid, List, Table, Download, Images } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
 import { ViewMode } from "@/types/inventory";
 
 interface FilterHeaderProps {
   viewMode: ViewMode;
   setViewMode: (mode: ViewMode) => void;
   onDownloadCSV?: () => void;
+  onDownloadJSON?: () => void;
   onDownloadImages?: () => void;
 }
 
@@ -14,23 +20,39 @@ export function FilterHeader({
   viewMode,
   setViewMode,
   onDownloadCSV,
+  onDownloadJSON,
   onDownloadImages,
 }: FilterHeaderProps) {
   return (
     <div className="flex items-center justify-between bg-card p-4 rounded-lg border shadow-sm">
-      <h3 className="text-lg font-semibold text-slate-900">Filter & View Options</h3>
+      <h3 className="text-lg font-semibold text-slate-900">
+        Filter & View Options
+      </h3>
       <div className="flex items-center gap-2">
-        {onDownloadCSV && (
-          <Button variant="outline" size="sm" onClick={onDownloadCSV}>
-            <Download className="w-4 h-4 mr-2" />
-            Selected CSV
-          </Button>
-        )}
-        {onDownloadImages && (
-          <Button variant="outline" size="sm" onClick={onDownloadImages}>
-            <Images className="w-4 h-4 mr-2" />
-            Selected Images
-          </Button>
+        {(onDownloadCSV || onDownloadJSON || onDownloadImages) && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm">
+                <Download className="w-4 h-4 mr-2" />
+                Download Selected
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              {onDownloadCSV && (
+                <DropdownMenuItem onClick={onDownloadCSV}>CSV</DropdownMenuItem>
+              )}
+              {onDownloadJSON && (
+                <DropdownMenuItem onClick={onDownloadJSON}>
+                  JSON
+                </DropdownMenuItem>
+              )}
+              {onDownloadImages && (
+                <DropdownMenuItem onClick={onDownloadImages}>
+                  Images
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
         <div className="flex border rounded-md">
           <Button

--- a/src/pages/AllItems.tsx
+++ b/src/pages/AllItems.tsx
@@ -1,4 +1,3 @@
-
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AppSidebar } from "@/components/AppSidebar";
@@ -12,7 +11,12 @@ import { ItemDetailDialog } from "@/components/ItemDetailDialog";
 import { ItemHistoryDialog } from "@/components/ItemHistoryDialog";
 import { EmptyState } from "@/components/EmptyState";
 import { sampleDecorItems } from "@/data/sampleData";
-import { fetchDecorItems, deleteDecorItem, restoreDecorItem, updateDecorItem } from "@/lib/api";
+import {
+  fetchDecorItems,
+  deleteDecorItem,
+  restoreDecorItem,
+  updateDecorItem,
+} from "@/lib/api";
 import { BatchLocationDialog } from "@/components/BatchLocationDialog";
 import { Button } from "@/components/ui/button";
 import { DecorItem } from "@/types/inventory";
@@ -31,7 +35,10 @@ const AllItems = () => {
   const [selectedRoom, setSelectedRoom] = useState<string[]>([]); // stores "houseId|roomId"
   const [selectedYear, setSelectedYear] = useState<string[]>([]);
   const [selectedArtist, setSelectedArtist] = useState<string[]>([]);
-  const [valuationRange, setValuationRange] = useState<{ min?: number; max?: number }>({});
+  const [valuationRange, setValuationRange] = useState<{
+    min?: number;
+    max?: number;
+  }>({});
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const [items, setItems] = useState<DecorItem[]>(sampleDecorItems);
   const [selectedItem, setSelectedItem] = useState<DecorItem | null>(null);
@@ -39,15 +46,19 @@ const AllItems = () => {
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [locationDialogOpen, setLocationDialogOpen] = useState(false);
   const [sortField, setSortField] = useState<string>("");
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
   const { houses, categories } = useSettingsState();
   const { toast } = useToast();
 
-  const yearOptions = Array.from(new Set(items.map(i => i.yearPeriod).filter(Boolean)));
-  const artistOptions = Array.from(new Set(items.map(i => i.artist).filter(Boolean)));
+  const yearOptions = Array.from(
+    new Set(items.map((i) => i.yearPeriod).filter(Boolean)),
+  );
+  const artistOptions = Array.from(
+    new Set(items.map((i) => i.artist).filter(Boolean)),
+  );
 
   const handleEdit = (item: DecorItem) => {
-    localStorage.setItem('editingDraft', JSON.stringify(item));
+    localStorage.setItem("editingDraft", JSON.stringify(item));
     navigate(`/add?draftId=${item.id}`);
   };
 
@@ -55,18 +66,18 @@ const AllItems = () => {
     if (!window.confirm(`Delete "${item.title}"?`)) return;
     deleteDecorItem(item.id)
       .then(() => {
-        setItems(prev => prev.filter(i => i.id !== item.id));
+        setItems((prev) => prev.filter((i) => i.id !== item.id));
         toast({
-          title: 'Item deleted',
-          description: 'The item has been removed successfully',
+          title: "Item deleted",
+          description: "The item has been removed successfully",
         });
         setSelectedItem(null);
       })
       .catch(() => {
         toast({
-          title: 'Error deleting item',
-          description: 'There was a problem deleting the item',
-          variant: 'destructive',
+          title: "Error deleting item",
+          description: "There was a problem deleting the item",
+          variant: "destructive",
         });
       });
   };
@@ -78,46 +89,71 @@ const AllItems = () => {
   const handleRestore = (version: DecorItem) => {
     if (!historyItem) return;
     restoreDecorItem(historyItem.id, version)
-      .then(updated => {
-        setItems(prev => prev.map(i => i.id === updated.id ? updated : i));
+      .then((updated) => {
+        setItems((prev) =>
+          prev.map((i) => (i.id === updated.id ? updated : i)),
+        );
         setHistoryItem(updated);
         setSelectedItem(updated);
         toast({
-          title: 'Item restored',
-          description: 'The selected version has been restored',
+          title: "Item restored",
+          description: "The selected version has been restored",
         });
       })
       .catch(() => {
         toast({
-          title: 'Error restoring item',
-          description: 'There was a problem restoring this version',
-          variant: 'destructive',
+          title: "Error restoring item",
+          description: "There was a problem restoring this version",
+          variant: "destructive",
         });
       });
   };
 
   useEffect(() => {
     fetchDecorItems()
-      .then(data => setItems(data))
+      .then((data) => setItems(data))
       .catch(() => {});
   }, []);
 
-  const filteredItems = items.filter(item => {
-    const matchesSearch = item.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         item.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         (item.artist && item.artist.toLowerCase().includes(searchTerm.toLowerCase()));
+  const filteredItems = items.filter((item) => {
+    const matchesSearch =
+      item.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      item.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (item.artist &&
+        item.artist.toLowerCase().includes(searchTerm.toLowerCase()));
 
-    const matchesCategory = selectedCategory.length === 0 || selectedCategory.includes(item.category);
-    const matchesSubcategory = selectedSubcategory.length === 0 || (item.subcategory && selectedSubcategory.includes(item.subcategory));
-    const matchesHouse = selectedHouse.length === 0 || (item.house && selectedHouse.includes(item.house));
-    const matchesRoom = selectedRoom.length === 0 || (item.room && selectedRoom.includes(`${item.house}|${item.room}`));
-    const matchesYear = selectedYear.length === 0 || (item.yearPeriod && selectedYear.includes(item.yearPeriod));
-    const matchesArtist = selectedArtist.length === 0 || (item.artist && selectedArtist.includes(item.artist));
+    const matchesCategory =
+      selectedCategory.length === 0 || selectedCategory.includes(item.category);
+    const matchesSubcategory =
+      selectedSubcategory.length === 0 ||
+      (item.subcategory && selectedSubcategory.includes(item.subcategory));
+    const matchesHouse =
+      selectedHouse.length === 0 ||
+      (item.house && selectedHouse.includes(item.house));
+    const matchesRoom =
+      selectedRoom.length === 0 ||
+      (item.room && selectedRoom.includes(`${item.house}|${item.room}`));
+    const matchesYear =
+      selectedYear.length === 0 ||
+      (item.yearPeriod && selectedYear.includes(item.yearPeriod));
+    const matchesArtist =
+      selectedArtist.length === 0 ||
+      (item.artist && selectedArtist.includes(item.artist));
     const valuation = item.valuation ?? 0;
-    const matchesValuation = (valuationRange.min === undefined || valuation >= valuationRange.min) &&
-                             (valuationRange.max === undefined || valuation <= valuationRange.max);
+    const matchesValuation =
+      (valuationRange.min === undefined || valuation >= valuationRange.min) &&
+      (valuationRange.max === undefined || valuation <= valuationRange.max);
 
-    return matchesSearch && matchesCategory && matchesSubcategory && matchesHouse && matchesRoom && matchesYear && matchesArtist && matchesValuation;
+    return (
+      matchesSearch &&
+      matchesCategory &&
+      matchesSubcategory &&
+      matchesHouse &&
+      matchesRoom &&
+      matchesYear &&
+      matchesArtist &&
+      matchesValuation
+    );
   });
 
   // Sort filtered items
@@ -126,50 +162,87 @@ const AllItems = () => {
     sortField,
     sortDirection,
     houses,
-    categories
+    categories,
   );
 
-  const handleSort = (field: string, direction: 'asc' | 'desc') => {
+  const handleSort = (field: string, direction: "asc" | "desc") => {
     setSortField(field);
     setSortDirection(direction);
   };
 
   const downloadCSV = () => {
     const headers = [
-      'ID', 'Title', 'Artist', 'Category', 'Subcategory', 'Width (cm)', 'Height (cm)', 'Depth (cm)', 'Valuation',
-      'Valuation Currency', 'Quantity', 'Year/Period', 'Description',
-      'House', 'Room', 'Notes'
+      "ID",
+      "Title",
+      "Artist",
+      "Category",
+      "Subcategory",
+      "Width (cm)",
+      "Height (cm)",
+      "Depth (cm)",
+      "Valuation",
+      "Valuation Currency",
+      "Quantity",
+      "Year/Period",
+      "Description",
+      "House",
+      "Room",
+      "Notes",
     ];
 
     const csvContent = [
-      headers.join(','),
-      ...sortedItems.map(item => [
-        item.id || '',
-        `"${item.title || ''}"`,
-        `"${item.artist || ''}"`,
-        `"${item.category || ''}"`,
-        `"${item.subcategory || ''}"`,
-        item.widthCm ?? '',
-        item.heightCm ?? '',
-        item.depthCm ?? '',
-        item.valuation || '',
-        `"${item.valuationCurrency || ''}"`,
-        item.quantity || '',
-        `"${item.yearPeriod || ''}"`,
-        `"${item.description || ''}"`,
-        `"${item.house || ''}"`,
-        `"${item.room || ''}"`,
-        `"${item.notes || ''}"`
-      ].join(','))
-    ].join('\n');
+      headers.join(","),
+      ...sortedItems.map((item) =>
+        [
+          item.id || "",
+          `"${item.title || ""}"`,
+          `"${item.artist || ""}"`,
+          `"${item.category || ""}"`,
+          `"${item.subcategory || ""}"`,
+          item.widthCm ?? "",
+          item.heightCm ?? "",
+          item.depthCm ?? "",
+          item.valuation || "",
+          `"${item.valuationCurrency || ""}"`,
+          item.quantity || "",
+          `"${item.yearPeriod || ""}"`,
+          `"${item.description || ""}"`,
+          `"${item.house || ""}"`,
+          `"${item.room || ""}"`,
+          `"${item.notes || ""}"`,
+        ].join(","),
+      ),
+    ].join("\n");
 
     // Create and download the CSV file
-    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-    const link = document.createElement('a');
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const link = document.createElement("a");
     const url = URL.createObjectURL(blob);
-    link.setAttribute('href', url);
-    link.setAttribute('download', `inventory_${new Date().toISOString().split('T')[0]}.csv`);
-    link.style.visibility = 'hidden';
+    link.setAttribute("href", url);
+    link.setAttribute(
+      "download",
+      `inventory_${new Date().toISOString().split("T")[0]}.csv`,
+    );
+    link.style.visibility = "hidden";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const downloadJSON = () => {
+    const jsonContent = JSON.stringify(sortedItems, null, 2);
+    const blob = new Blob([jsonContent], {
+      type: "application/json;charset=utf-8;",
+    });
+    const link = document.createElement("a");
+    const url = URL.createObjectURL(blob);
+    link.setAttribute("href", url);
+    link.setAttribute(
+      "download",
+      `inventory_${new Date().toISOString().split("T")[0]}.json`,
+    );
+    link.style.visibility = "hidden";
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -179,62 +252,76 @@ const AllItems = () => {
   const handleBatchLocation = (house: string, room: string) => {
     const ids = [...selectedIds];
     downloadCSV();
-    Promise.all(ids.map(id => updateDecorItem(id, { house, room } as unknown as DecorItem)))
-      .then(updated => {
-        setItems(prev => prev.map(it => {
-          const match = updated.find(u => u.id === it.id);
-          return match ? match : it;
-        }));
+    Promise.all(
+      ids.map((id) =>
+        updateDecorItem(id, { house, room } as unknown as DecorItem),
+      ),
+    )
+      .then((updated) => {
+        setItems((prev) =>
+          prev.map((it) => {
+            const match = updated.find((u) => u.id === it.id);
+            return match ? match : it;
+          }),
+        );
         toast({
-          title: 'Items updated',
-          description: `${ids.length} item${ids.length === 1 ? '' : 's'} moved`,
+          title: "Items updated",
+          description: `${ids.length} item${ids.length === 1 ? "" : "s"} moved`,
         });
         setSelectedIds([]);
       })
       .catch(() => {
         toast({
-          title: 'Error updating items',
-          description: 'There was a problem updating the selected items',
-          variant: 'destructive',
+          title: "Error updating items",
+          description: "There was a problem updating the selected items",
+          variant: "destructive",
         });
       });
   };
 
   const handleBatchDelete = () => {
-    if (!window.confirm(`Delete ${selectedIds.length} item${selectedIds.length === 1 ? '' : 's'}?`)) return;
+    if (
+      !window.confirm(
+        `Delete ${selectedIds.length} item${selectedIds.length === 1 ? "" : "s"}?`,
+      )
+    )
+      return;
     const ids = [...selectedIds];
     downloadCSV();
-    Promise.all(ids.map(id => deleteDecorItem(id)))
+    Promise.all(ids.map((id) => deleteDecorItem(id)))
       .then(() => {
-        setItems(prev => prev.filter(i => !ids.includes(i.id.toString())));
+        setItems((prev) => prev.filter((i) => !ids.includes(i.id.toString())));
         toast({
-          title: 'Items deleted',
-          description: `${ids.length} item${ids.length === 1 ? '' : 's'} removed`,
+          title: "Items deleted",
+          description: `${ids.length} item${ids.length === 1 ? "" : "s"} removed`,
         });
         setSelectedIds([]);
       })
       .catch(() => {
         toast({
-          title: 'Error deleting items',
-          description: 'There was a problem deleting the selected items',
-          variant: 'destructive',
+          title: "Error deleting items",
+          description: "There was a problem deleting the selected items",
+          variant: "destructive",
         });
       });
   };
-
 
   return (
     <SidebarProvider>
       <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
-        
+
         <div className="flex-1 flex flex-col">
           <InventoryHeader />
 
           <main className="flex-1 p-6">
             <div className="mb-6">
-              <h2 className="text-xl font-semibold text-slate-900 mb-2">All Items</h2>
-              <p className="text-slate-600">Browse and manage your entire collection</p>
+              <h2 className="text-xl font-semibold text-slate-900 mb-2">
+                All Items
+              </h2>
+              <p className="text-slate-600">
+                Browse and manage your entire collection
+              </p>
             </div>
 
             <SearchFilters
@@ -259,13 +346,21 @@ const AllItems = () => {
               viewMode={viewMode}
               setViewMode={setViewMode}
               onDownloadCSV={downloadCSV}
+              onDownloadJSON={downloadJSON}
             />
 
             {selectedIds.length > 0 && (
               <div className="mb-6 flex flex-wrap items-center justify-between gap-2 bg-blue-100 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 text-blue-800 dark:text-blue-100 px-4 py-2 rounded">
-                <span className="text-sm font-medium">{selectedIds.length} item{selectedIds.length === 1 ? '' : 's'} selected</span>
+                <span className="text-sm font-medium">
+                  {selectedIds.length} item{selectedIds.length === 1 ? "" : "s"}{" "}
+                  selected
+                </span>
                 <div className="flex items-center gap-2">
-                  <Button variant="link" size="sm" onClick={() => setLocationDialogOpen(true)}>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    onClick={() => setLocationDialogOpen(true)}
+                  >
                     Change Location
                   </Button>
                   <Button
@@ -276,7 +371,11 @@ const AllItems = () => {
                   >
                     Delete
                   </Button>
-                  <Button variant="link" size="sm" onClick={() => setSelectedIds([])}>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    onClick={() => setSelectedIds([])}
+                  >
                     Clear
                   </Button>
                 </div>

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -1,4 +1,3 @@
-
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { AppSidebar } from "@/components/AppSidebar";
@@ -12,7 +11,12 @@ import { ItemDetailDialog } from "@/components/ItemDetailDialog";
 import { ItemHistoryDialog } from "@/components/ItemHistoryDialog";
 import { EmptyState } from "@/components/EmptyState";
 import { sampleDecorItems } from "@/data/sampleData";
-import { fetchDecorItems, deleteDecorItem, restoreDecorItem, updateDecorItem } from "@/lib/api";
+import {
+  fetchDecorItems,
+  deleteDecorItem,
+  restoreDecorItem,
+  updateDecorItem,
+} from "@/lib/api";
 import { BatchLocationDialog } from "@/components/BatchLocationDialog";
 import { Button } from "@/components/ui/button";
 import { DecorItem } from "@/types/inventory";
@@ -26,13 +30,18 @@ const CategoryPage = () => {
   const { categoryId } = useParams<{ categoryId: string }>();
   const navigate = useNavigate();
   const [searchTerm, setSearchTerm] = useState("");
-  const [selectedCategory, setSelectedCategory] = useState<string[]>(categoryId ? [categoryId] : []);
+  const [selectedCategory, setSelectedCategory] = useState<string[]>(
+    categoryId ? [categoryId] : [],
+  );
   const [selectedSubcategory, setSelectedSubcategory] = useState<string[]>([]);
   const [selectedHouse, setSelectedHouse] = useState<string[]>([]);
   const [selectedRoom, setSelectedRoom] = useState<string[]>([]); // stores "houseId|roomId"
   const [selectedYear, setSelectedYear] = useState<string[]>([]);
   const [selectedArtist, setSelectedArtist] = useState<string[]>([]);
-  const [valuationRange, setValuationRange] = useState<{ min?: number; max?: number }>({});
+  const [valuationRange, setValuationRange] = useState<{
+    min?: number;
+    max?: number;
+  }>({});
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const [items, setItems] = useState<DecorItem[]>(sampleDecorItems);
   const [selectedItem, setSelectedItem] = useState<DecorItem | null>(null);
@@ -40,14 +49,18 @@ const CategoryPage = () => {
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [locationDialogOpen, setLocationDialogOpen] = useState(false);
   const [sortField, setSortField] = useState<string>("");
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
   const { categories, houses } = useSettingsState();
   const { toast } = useToast();
-  const yearOptions = Array.from(new Set(items.map(i => i.yearPeriod).filter(Boolean)));
-  const artistOptions = Array.from(new Set(items.map(i => i.artist).filter(Boolean)));
+  const yearOptions = Array.from(
+    new Set(items.map((i) => i.yearPeriod).filter(Boolean)),
+  );
+  const artistOptions = Array.from(
+    new Set(items.map((i) => i.artist).filter(Boolean)),
+  );
 
   const handleEdit = (item: DecorItem) => {
-    localStorage.setItem('editingDraft', JSON.stringify(item));
+    localStorage.setItem("editingDraft", JSON.stringify(item));
     navigate(`/add?draftId=${item.id}`);
   };
 
@@ -55,18 +68,18 @@ const CategoryPage = () => {
     if (!window.confirm(`Delete "${item.title}"?`)) return;
     deleteDecorItem(item.id)
       .then(() => {
-        setItems(prev => prev.filter(i => i.id !== item.id));
+        setItems((prev) => prev.filter((i) => i.id !== item.id));
         toast({
-          title: 'Item deleted',
-          description: 'The item has been removed successfully',
+          title: "Item deleted",
+          description: "The item has been removed successfully",
         });
         setSelectedItem(null);
       })
       .catch(() => {
         toast({
-          title: 'Error deleting item',
-          description: 'There was a problem deleting the item',
-          variant: 'destructive',
+          title: "Error deleting item",
+          description: "There was a problem deleting the item",
+          variant: "destructive",
         });
       });
   };
@@ -78,68 +91,112 @@ const CategoryPage = () => {
   const handleRestore = (version: DecorItem) => {
     if (!historyItem) return;
     restoreDecorItem(historyItem.id, version)
-      .then(updated => {
-        setItems(prev => prev.map(i => i.id === updated.id ? updated : i));
+      .then((updated) => {
+        setItems((prev) =>
+          prev.map((i) => (i.id === updated.id ? updated : i)),
+        );
         setHistoryItem(updated);
         setSelectedItem(updated);
         toast({
-          title: 'Item restored',
-          description: 'The selected version has been restored',
+          title: "Item restored",
+          description: "The selected version has been restored",
         });
       })
       .catch(() => {
         toast({
-          title: 'Error restoring item',
-          description: 'There was a problem restoring this version',
-          variant: 'destructive',
+          title: "Error restoring item",
+          description: "There was a problem restoring this version",
+          variant: "destructive",
         });
       });
   };
 
   const downloadSelectedCSV = () => {
     const headers = [
-      'ID', 'Title', 'Artist', 'Category', 'Subcategory', 'Width (cm)', 'Height (cm)', 'Depth (cm)', 'Valuation',
-      'Valuation Currency', 'Quantity', 'Year/Period', 'Description',
-      'House', 'Room', 'Notes'
+      "ID",
+      "Title",
+      "Artist",
+      "Category",
+      "Subcategory",
+      "Width (cm)",
+      "Height (cm)",
+      "Depth (cm)",
+      "Valuation",
+      "Valuation Currency",
+      "Quantity",
+      "Year/Period",
+      "Description",
+      "House",
+      "Room",
+      "Notes",
     ];
 
     // If no items are selected, download all filtered items
     // If items are selected, download only selected items
-    const itemsToDownload = selectedIds.length > 0 
-      ? sortedItems.filter(item => selectedIds.includes(item.id.toString()))
-      : sortedItems;
+    const itemsToDownload =
+      selectedIds.length > 0
+        ? sortedItems.filter((item) => selectedIds.includes(item.id.toString()))
+        : sortedItems;
 
     const csvContent = [
-      headers.join(','),
-      ...itemsToDownload.map(item => [
-        item.id || '',
-        `"${item.title || ''}"`,
-        `"${item.artist || ''}"`,
-        `"${item.category || ''}"`,
-        `"${item.subcategory || ''}"`,
-        item.widthCm ?? '',
-        item.heightCm ?? '',
-        item.depthCm ?? '',
-        item.valuation || '',
-        `"${item.valuationCurrency || ''}"`,
-        item.quantity || '',
-        `"${item.yearPeriod || ''}"`,
-        `"${item.description || ''}"`,
-        `"${item.house || ''}"`,
-        `"${item.room || ''}"`,
-        `"${item.notes || ''}"`
-      ].join(','))
-    ].join('\n');
+      headers.join(","),
+      ...itemsToDownload.map((item) =>
+        [
+          item.id || "",
+          `"${item.title || ""}"`,
+          `"${item.artist || ""}"`,
+          `"${item.category || ""}"`,
+          `"${item.subcategory || ""}"`,
+          item.widthCm ?? "",
+          item.heightCm ?? "",
+          item.depthCm ?? "",
+          item.valuation || "",
+          `"${item.valuationCurrency || ""}"`,
+          item.quantity || "",
+          `"${item.yearPeriod || ""}"`,
+          `"${item.description || ""}"`,
+          `"${item.house || ""}"`,
+          `"${item.room || ""}"`,
+          `"${item.notes || ""}"`,
+        ].join(","),
+      ),
+    ].join("\n");
 
-    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-    const link = document.createElement('a');
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const link = document.createElement("a");
     const url = URL.createObjectURL(blob);
-    link.setAttribute('href', url);
-    const filename = selectedIds.length > 0 
-      ? `selected_items_${new Date().toISOString().split('T')[0]}.csv`
-      : `filtered_items_${new Date().toISOString().split('T')[0]}.csv`;
-    link.setAttribute('download', filename);
-    link.style.visibility = 'hidden';
+    link.setAttribute("href", url);
+    const filename =
+      selectedIds.length > 0
+        ? `selected_items_${new Date().toISOString().split("T")[0]}.csv`
+        : `filtered_items_${new Date().toISOString().split("T")[0]}.csv`;
+    link.setAttribute("download", filename);
+    link.style.visibility = "hidden";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  const downloadSelectedJSON = () => {
+    const itemsToDownload =
+      selectedIds.length > 0
+        ? sortedItems.filter((item) => selectedIds.includes(item.id.toString()))
+        : sortedItems;
+
+    const jsonContent = JSON.stringify(itemsToDownload, null, 2);
+    const blob = new Blob([jsonContent], {
+      type: "application/json;charset=utf-8;",
+    });
+    const link = document.createElement("a");
+    const url = URL.createObjectURL(blob);
+    const filename =
+      selectedIds.length > 0
+        ? `selected_items_${new Date().toISOString().split("T")[0]}.json`
+        : `filtered_items_${new Date().toISOString().split("T")[0]}.json`;
+    link.setAttribute("href", url);
+    link.setAttribute("download", filename);
+    link.style.visibility = "hidden";
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -147,13 +204,15 @@ const CategoryPage = () => {
   };
 
   const downloadSelectedImages = () => {
-    console.log('Downloading selected images...');
-    alert('Selected images download functionality requires backend implementation');
+    console.log("Downloading selected images...");
+    alert(
+      "Selected images download functionality requires backend implementation",
+    );
   };
 
   useEffect(() => {
     fetchDecorItems()
-      .then(data => setItems(data))
+      .then((data) => setItems(data))
       .catch(() => {});
   }, []);
 
@@ -168,24 +227,46 @@ const CategoryPage = () => {
     setSearchTerm("");
   }, [categoryId]);
 
-  const categoryConfig = categories.find(c => c.id === categoryId);
+  const categoryConfig = categories.find((c) => c.id === categoryId);
   const categoryName = categoryConfig?.name || "Items";
 
-  const filteredItems = items.filter(item => {
-    const matchesSearch = item.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         item.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         (item.artist && item.artist.toLowerCase().includes(searchTerm.toLowerCase()));
+  const filteredItems = items.filter((item) => {
+    const matchesSearch =
+      item.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      item.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (item.artist &&
+        item.artist.toLowerCase().includes(searchTerm.toLowerCase()));
     const matchesCategory = item.category === categoryId;
-    const matchesSubcategory = selectedSubcategory.length === 0 || (item.subcategory && selectedSubcategory.includes(item.subcategory));
-    const matchesHouse = selectedHouse.length === 0 || (item.house && selectedHouse.includes(item.house));
-    const matchesRoom = selectedRoom.length === 0 || (item.room && selectedRoom.includes(`${item.house}|${item.room}`));
-    const matchesYear = selectedYear.length === 0 || (item.yearPeriod && selectedYear.includes(item.yearPeriod));
-    const matchesArtist = selectedArtist.length === 0 || (item.artist && selectedArtist.includes(item.artist));
+    const matchesSubcategory =
+      selectedSubcategory.length === 0 ||
+      (item.subcategory && selectedSubcategory.includes(item.subcategory));
+    const matchesHouse =
+      selectedHouse.length === 0 ||
+      (item.house && selectedHouse.includes(item.house));
+    const matchesRoom =
+      selectedRoom.length === 0 ||
+      (item.room && selectedRoom.includes(`${item.house}|${item.room}`));
+    const matchesYear =
+      selectedYear.length === 0 ||
+      (item.yearPeriod && selectedYear.includes(item.yearPeriod));
+    const matchesArtist =
+      selectedArtist.length === 0 ||
+      (item.artist && selectedArtist.includes(item.artist));
     const valuation = item.valuation ?? 0;
-    const matchesValuation = (valuationRange.min === undefined || valuation >= valuationRange.min) &&
-                             (valuationRange.max === undefined || valuation <= valuationRange.max);
+    const matchesValuation =
+      (valuationRange.min === undefined || valuation >= valuationRange.min) &&
+      (valuationRange.max === undefined || valuation <= valuationRange.max);
 
-    return matchesSearch && matchesCategory && matchesSubcategory && matchesHouse && matchesRoom && matchesYear && matchesArtist && matchesValuation;
+    return (
+      matchesSearch &&
+      matchesCategory &&
+      matchesSubcategory &&
+      matchesHouse &&
+      matchesRoom &&
+      matchesYear &&
+      matchesArtist &&
+      matchesValuation
+    );
   });
 
   const sortedItems = sortInventoryItems(
@@ -193,57 +274,66 @@ const CategoryPage = () => {
     sortField,
     sortDirection,
     houses,
-    categories
+    categories,
   );
 
-  const handleSort = (field: string, direction: 'asc' | 'desc') => {
+  const handleSort = (field: string, direction: "asc" | "desc") => {
     setSortField(field);
     setSortDirection(direction);
   };
 
   const handleBatchLocation = (house: string, room: string) => {
     const ids = [...selectedIds];
-    Promise.all(ids.map(id => updateDecorItem(id, { house, room } as unknown as DecorItem)))
-      .then(updated => {
-        setItems(prev =>
-          prev.map(it => {
-            const match = updated.find(u => u.id === it.id);
+    Promise.all(
+      ids.map((id) =>
+        updateDecorItem(id, { house, room } as unknown as DecorItem),
+      ),
+    )
+      .then((updated) => {
+        setItems((prev) =>
+          prev.map((it) => {
+            const match = updated.find((u) => u.id === it.id);
             return match ? match : it;
-          })
+          }),
         );
         toast({
-          title: 'Items updated',
-          description: `${ids.length} item${ids.length === 1 ? '' : 's'} moved`,
+          title: "Items updated",
+          description: `${ids.length} item${ids.length === 1 ? "" : "s"} moved`,
         });
         setSelectedIds([]);
         setLocationDialogOpen(false); // Close the dialog after successful update
       })
       .catch(() => {
         toast({
-          title: 'Error updating items',
-          description: 'There was a problem updating the selected items',
-          variant: 'destructive',
+          title: "Error updating items",
+          description: "There was a problem updating the selected items",
+          variant: "destructive",
         });
       });
   };
 
   const handleBatchDelete = () => {
-    if (!window.confirm(`Delete ${selectedIds.length} item${selectedIds.length === 1 ? '' : 's'}?`)) return;
+    if (
+      !window.confirm(
+        `Delete ${selectedIds.length} item${selectedIds.length === 1 ? "" : "s"}?`,
+      )
+    )
+      return;
     const ids = [...selectedIds];
-    Promise.all(ids.map(id => deleteDecorItem(id)))
+    Promise.all(ids.map((id) => deleteDecorItem(id)))
       .then(() => {
-        setItems(prev => prev.filter(i => !ids.includes(i.id.toString())));
+        setItems((prev) => prev.filter((i) => !ids.includes(i.id.toString())));
         toast({
-          title: 'Items deleted',
-          description: `${ids.length} item${ids.length === 1 ? '' : 's'} removed`,
+          title: "Items deleted",
+          description: `${ids.length} item${ids.length === 1 ? "" : "s"} removed`,
         });
         setSelectedIds([]);
       })
       .catch(() => {
         toast({
-          title: 'Error deleting items',
-          description: 'There was a problem deleting the selected items',
-          variant: 'destructive',
+          title: "Error deleting items",
+          description: "There was a problem deleting the selected items",
+          variant: "destructive",
         });
       });
   };
@@ -258,8 +348,12 @@ const CategoryPage = () => {
 
           <main className="flex-1 p-6">
             <div className="mb-6">
-              <h2 className="text-xl font-semibold text-slate-900 mb-2">{categoryName} Collection</h2>
-              <p className="text-slate-600">Browse and manage your {categoryName} pieces</p>
+              <h2 className="text-xl font-semibold text-slate-900 mb-2">
+                {categoryName} Collection
+              </h2>
+              <p className="text-slate-600">
+                Browse and manage your {categoryName} pieces
+              </p>
             </div>
 
             <SearchFilters
@@ -284,15 +378,23 @@ const CategoryPage = () => {
               viewMode={viewMode}
               setViewMode={setViewMode}
               onDownloadCSV={downloadSelectedCSV}
+              onDownloadJSON={downloadSelectedJSON}
               onDownloadImages={downloadSelectedImages}
               permanentCategory={categoryId}
             />
 
             {selectedIds.length > 0 && (
               <div className="mb-6 flex flex-wrap items-center justify-between gap-2 bg-blue-100 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 text-blue-800 dark:text-blue-100 px-4 py-2 rounded">
-                <span className="text-sm font-medium">{selectedIds.length} item{selectedIds.length === 1 ? '' : 's'} selected</span>
+                <span className="text-sm font-medium">
+                  {selectedIds.length} item{selectedIds.length === 1 ? "" : "s"}{" "}
+                  selected
+                </span>
                 <div className="flex items-center gap-2">
-                  <Button variant="link" size="sm" onClick={() => setLocationDialogOpen(true)}>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    onClick={() => setLocationDialogOpen(true)}
+                  >
                     Change Location
                   </Button>
                   <Button
@@ -302,7 +404,11 @@ const CategoryPage = () => {
                   >
                     Delete
                   </Button>
-                  <Button variant="link" size="sm" onClick={() => setSelectedIds([])}>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    onClick={() => setSelectedIds([])}
+                  >
                     Clear
                   </Button>
                 </div>

--- a/src/pages/HousePage.tsx
+++ b/src/pages/HousePage.tsx
@@ -1,4 +1,3 @@
-
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { AppSidebar } from "@/components/AppSidebar";
@@ -12,7 +11,12 @@ import { ItemDetailDialog } from "@/components/ItemDetailDialog";
 import { ItemHistoryDialog } from "@/components/ItemHistoryDialog";
 import { EmptyState } from "@/components/EmptyState";
 import { sampleDecorItems } from "@/data/sampleData";
-import { fetchDecorItems, deleteDecorItem, restoreDecorItem, updateDecorItem } from "@/lib/api";
+import {
+  fetchDecorItems,
+  deleteDecorItem,
+  restoreDecorItem,
+  updateDecorItem,
+} from "@/lib/api";
 import { BatchLocationDialog } from "@/components/BatchLocationDialog";
 import { Button } from "@/components/ui/button";
 import { DecorItem } from "@/types/inventory";
@@ -28,11 +32,16 @@ const HousePage = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string[]>([]);
   const [selectedSubcategory, setSelectedSubcategory] = useState<string[]>([]);
-  const [selectedHouse, setSelectedHouse] = useState<string[]>(houseId ? [houseId] : []);
+  const [selectedHouse, setSelectedHouse] = useState<string[]>(
+    houseId ? [houseId] : [],
+  );
   const [selectedRoom, setSelectedRoom] = useState<string[]>([]); // stores "houseId|roomId"
   const [selectedYear, setSelectedYear] = useState<string[]>([]);
   const [selectedArtist, setSelectedArtist] = useState<string[]>([]);
-  const [valuationRange, setValuationRange] = useState<{ min?: number; max?: number }>({});
+  const [valuationRange, setValuationRange] = useState<{
+    min?: number;
+    max?: number;
+  }>({});
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const [items, setItems] = useState<DecorItem[]>(sampleDecorItems);
   const [selectedItem, setSelectedItem] = useState<DecorItem | null>(null);
@@ -40,14 +49,18 @@ const HousePage = () => {
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [locationDialogOpen, setLocationDialogOpen] = useState(false);
   const [sortField, setSortField] = useState<string>("");
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
   const { houses, categories } = useSettingsState();
   const { toast } = useToast();
-  const yearOptions = Array.from(new Set(items.map(i => i.yearPeriod).filter(Boolean)));
-  const artistOptions = Array.from(new Set(items.map(i => i.artist).filter(Boolean)));
+  const yearOptions = Array.from(
+    new Set(items.map((i) => i.yearPeriod).filter(Boolean)),
+  );
+  const artistOptions = Array.from(
+    new Set(items.map((i) => i.artist).filter(Boolean)),
+  );
 
   const handleEdit = (item: DecorItem) => {
-    localStorage.setItem('editingDraft', JSON.stringify(item));
+    localStorage.setItem("editingDraft", JSON.stringify(item));
     navigate(`/add?draftId=${item.id}`);
   };
 
@@ -55,18 +68,18 @@ const HousePage = () => {
     if (!window.confirm(`Delete "${item.title}"?`)) return;
     deleteDecorItem(item.id)
       .then(() => {
-        setItems(prev => prev.filter(i => i.id !== item.id));
+        setItems((prev) => prev.filter((i) => i.id !== item.id));
         toast({
-          title: 'Item deleted',
-          description: 'The item has been removed successfully',
+          title: "Item deleted",
+          description: "The item has been removed successfully",
         });
         setSelectedItem(null);
       })
       .catch(() => {
         toast({
-          title: 'Error deleting item',
-          description: 'There was a problem deleting the item',
-          variant: 'destructive',
+          title: "Error deleting item",
+          description: "There was a problem deleting the item",
+          variant: "destructive",
         });
       });
   };
@@ -78,27 +91,29 @@ const HousePage = () => {
   const handleRestore = (version: DecorItem) => {
     if (!historyItem) return;
     restoreDecorItem(historyItem.id, version)
-      .then(updated => {
-        setItems(prev => prev.map(i => i.id === updated.id ? updated : i));
+      .then((updated) => {
+        setItems((prev) =>
+          prev.map((i) => (i.id === updated.id ? updated : i)),
+        );
         setHistoryItem(updated);
         setSelectedItem(updated);
         toast({
-          title: 'Item restored',
-          description: 'The selected version has been restored',
+          title: "Item restored",
+          description: "The selected version has been restored",
         });
       })
       .catch(() => {
         toast({
-          title: 'Error restoring item',
-          description: 'There was a problem restoring this version',
-          variant: 'destructive',
+          title: "Error restoring item",
+          description: "There was a problem restoring this version",
+          variant: "destructive",
         });
       });
   };
 
   useEffect(() => {
     fetchDecorItems()
-      .then(data => setItems(data))
+      .then((data) => setItems(data))
       .catch(() => {});
   }, []);
 
@@ -113,112 +128,178 @@ const HousePage = () => {
     setSearchTerm("");
   }, [houseId]);
 
-  const currentHouse = houses.find(h => h.id === houseId);
+  const currentHouse = houses.find((h) => h.id === houseId);
   const houseName = currentHouse?.name || "Unknown House";
 
-  const filteredItems = items.filter(item => {
-    const matchesSearch = item.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         item.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         (item.artist && item.artist.toLowerCase().includes(searchTerm.toLowerCase()));
-    const matchesCategory = selectedCategory.length === 0 || selectedCategory.includes(item.category);
-    const matchesSubcategory = selectedSubcategory.length === 0 || (item.subcategory && selectedSubcategory.includes(item.subcategory));
+  const filteredItems = items.filter((item) => {
+    const matchesSearch =
+      item.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      item.description.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (item.artist &&
+        item.artist.toLowerCase().includes(searchTerm.toLowerCase()));
+    const matchesCategory =
+      selectedCategory.length === 0 || selectedCategory.includes(item.category);
+    const matchesSubcategory =
+      selectedSubcategory.length === 0 ||
+      (item.subcategory && selectedSubcategory.includes(item.subcategory));
     const matchesHouse = item.house === houseId;
-    const matchesRoom = selectedRoom.length === 0 || (item.room && selectedRoom.includes(`${item.house}|${item.room}`));
-    const matchesYear = selectedYear.length === 0 || (item.yearPeriod && selectedYear.includes(item.yearPeriod));
-    const matchesArtist = selectedArtist.length === 0 || (item.artist && selectedArtist.includes(item.artist));
+    const matchesRoom =
+      selectedRoom.length === 0 ||
+      (item.room && selectedRoom.includes(`${item.house}|${item.room}`));
+    const matchesYear =
+      selectedYear.length === 0 ||
+      (item.yearPeriod && selectedYear.includes(item.yearPeriod));
+    const matchesArtist =
+      selectedArtist.length === 0 ||
+      (item.artist && selectedArtist.includes(item.artist));
     const valuation = item.valuation ?? 0;
-    const matchesValuation = (valuationRange.min === undefined || valuation >= valuationRange.min) &&
-                             (valuationRange.max === undefined || valuation <= valuationRange.max);
+    const matchesValuation =
+      (valuationRange.min === undefined || valuation >= valuationRange.min) &&
+      (valuationRange.max === undefined || valuation <= valuationRange.max);
 
-    return matchesSearch && matchesCategory && matchesSubcategory && matchesHouse && matchesRoom && matchesYear && matchesArtist && matchesValuation;
+    return (
+      matchesSearch &&
+      matchesCategory &&
+      matchesSubcategory &&
+      matchesHouse &&
+      matchesRoom &&
+      matchesYear &&
+      matchesArtist &&
+      matchesValuation
+    );
   });
 
   const downloadCSV = () => {
     const headers = [
-      'ID', 'Title', 'Artist', 'Category', 'Subcategory', 'Width (cm)', 'Height (cm)', 'Depth (cm)', 'Valuation',
-      'Valuation Currency', 'Quantity', 'Year/Period', 'Description',
-      'House', 'Room', 'Notes'
+      "ID",
+      "Title",
+      "Artist",
+      "Category",
+      "Subcategory",
+      "Width (cm)",
+      "Height (cm)",
+      "Depth (cm)",
+      "Valuation",
+      "Valuation Currency",
+      "Quantity",
+      "Year/Period",
+      "Description",
+      "House",
+      "Room",
+      "Notes",
     ];
 
     const csvContent = [
-      headers.join(','),
-      ...filteredItems.map(item => [
-        item.id || '',
-        `"${item.title || ''}"`,
-        `"${item.artist || ''}"`,
-        `"${item.category || ''}"`,
-        `"${item.subcategory || ''}"`,
-        item.widthCm ?? '',
-        item.heightCm ?? '',
-        item.depthCm ?? '',
-        item.valuation || '',
-        `"${item.valuationCurrency || ''}"`,
-        item.quantity || '',
-        `"${item.yearPeriod || ''}"`,
-        `"${item.description || ''}"`,
-        `"${item.house || ''}"`,
-        `"${item.room || ''}"`,
-        `"${item.notes || ''}"`
-      ].join(','))
-    ].join('\n');
+      headers.join(","),
+      ...filteredItems.map((item) =>
+        [
+          item.id || "",
+          `"${item.title || ""}"`,
+          `"${item.artist || ""}"`,
+          `"${item.category || ""}"`,
+          `"${item.subcategory || ""}"`,
+          item.widthCm ?? "",
+          item.heightCm ?? "",
+          item.depthCm ?? "",
+          item.valuation || "",
+          `"${item.valuationCurrency || ""}"`,
+          item.quantity || "",
+          `"${item.yearPeriod || ""}"`,
+          `"${item.description || ""}"`,
+          `"${item.house || ""}"`,
+          `"${item.room || ""}"`,
+          `"${item.notes || ""}"`,
+        ].join(","),
+      ),
+    ].join("\n");
 
-    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-    const link = document.createElement('a');
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const link = document.createElement("a");
     const url = URL.createObjectURL(blob);
-    link.setAttribute('href', url);
-    link.setAttribute('download', `inventory_${new Date().toISOString().split('T')[0]}.csv`);
-    link.style.visibility = 'hidden';
+    link.setAttribute("href", url);
+    link.setAttribute(
+      "download",
+      `inventory_${new Date().toISOString().split("T")[0]}.csv`,
+    );
+    link.style.visibility = "hidden";
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
     URL.revokeObjectURL(url);
+  };
 
+  const downloadJSON = () => {
+    const jsonContent = JSON.stringify(filteredItems, null, 2);
+    const blob = new Blob([jsonContent], {
+      type: "application/json;charset=utf-8;",
+    });
+    const link = document.createElement("a");
+    const url = URL.createObjectURL(blob);
+    link.setAttribute("href", url);
+    link.setAttribute(
+      "download",
+      `inventory_${new Date().toISOString().split("T")[0]}.json`,
+    );
+    link.style.visibility = "hidden";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
   };
 
   const handleBatchLocation = (house: string, room: string) => {
     const ids = [...selectedIds];
     downloadCSV();
-    Promise.all(ids.map(id => updateDecorItem(id, { house, room } as unknown as DecorItem)))
-      .then(updated => {
-        setItems(prev =>
-          prev.map(it => {
-            const match = updated.find(u => u.id === it.id);
+    Promise.all(
+      ids.map((id) =>
+        updateDecorItem(id, { house, room } as unknown as DecorItem),
+      ),
+    )
+      .then((updated) => {
+        setItems((prev) =>
+          prev.map((it) => {
+            const match = updated.find((u) => u.id === it.id);
             return match ? match : it;
-          })
+          }),
         );
         toast({
-          title: 'Items updated',
-          description: `${ids.length} item${ids.length === 1 ? '' : 's'} moved`,
+          title: "Items updated",
+          description: `${ids.length} item${ids.length === 1 ? "" : "s"} moved`,
         });
         setSelectedIds([]);
       })
       .catch(() => {
         toast({
-          title: 'Error updating items',
-          description: 'There was a problem updating the selected items',
-          variant: 'destructive',
+          title: "Error updating items",
+          description: "There was a problem updating the selected items",
+          variant: "destructive",
         });
       });
   };
 
   const handleBatchDelete = () => {
-    if (!window.confirm(`Delete ${selectedIds.length} item${selectedIds.length === 1 ? '' : 's'}?`)) return;
+    if (
+      !window.confirm(
+        `Delete ${selectedIds.length} item${selectedIds.length === 1 ? "" : "s"}?`,
+      )
+    )
+      return;
     const ids = [...selectedIds];
     downloadCSV();
-    Promise.all(ids.map(id => deleteDecorItem(id)))
+    Promise.all(ids.map((id) => deleteDecorItem(id)))
       .then(() => {
-        setItems(prev => prev.filter(i => !ids.includes(i.id.toString())));
+        setItems((prev) => prev.filter((i) => !ids.includes(i.id.toString())));
         toast({
-          title: 'Items deleted',
-          description: `${ids.length} item${ids.length === 1 ? '' : 's'} removed`,
+          title: "Items deleted",
+          description: `${ids.length} item${ids.length === 1 ? "" : "s"} removed`,
         });
         setSelectedIds([]);
       })
       .catch(() => {
         toast({
-          title: 'Error deleting items',
-          description: 'There was a problem deleting the selected items',
-          variant: 'destructive',
+          title: "Error deleting items",
+          description: "There was a problem deleting the selected items",
+          variant: "destructive",
         });
       });
   };
@@ -228,26 +309,27 @@ const HousePage = () => {
     sortField,
     sortDirection,
     houses,
-    categories
+    categories,
   );
 
-  const handleSort = (field: string, direction: 'asc' | 'desc') => {
+  const handleSort = (field: string, direction: "asc" | "desc") => {
     setSortField(field);
     setSortDirection(direction);
   };
-
 
   return (
     <SidebarProvider>
       <div className="min-h-screen flex w-full bg-background">
         <AppSidebar />
-        
+
         <div className="flex-1 flex flex-col">
           <InventoryHeader />
 
           <main className="flex-1 p-6">
             <div className="mb-6">
-              <h2 className="text-xl font-semibold text-slate-900 mb-2">{houseName}</h2>
+              <h2 className="text-xl font-semibold text-slate-900 mb-2">
+                {houseName}
+              </h2>
               <p className="text-slate-600">Items located in {houseName}</p>
             </div>
 
@@ -273,14 +355,22 @@ const HousePage = () => {
               viewMode={viewMode}
               setViewMode={setViewMode}
               onDownloadCSV={downloadCSV}
+              onDownloadJSON={downloadJSON}
               permanentHouse={houseId}
             />
 
             {selectedIds.length > 0 && (
               <div className="mb-6 flex flex-wrap items-center justify-between gap-2 bg-blue-100 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 text-blue-800 dark:text-blue-100 px-4 py-2 rounded">
-                <span className="text-sm font-medium">{selectedIds.length} item{selectedIds.length === 1 ? '' : 's'} selected</span>
+                <span className="text-sm font-medium">
+                  {selectedIds.length} item{selectedIds.length === 1 ? "" : "s"}{" "}
+                  selected
+                </span>
                 <div className="flex items-center gap-2">
-                  <Button variant="link" size="sm" onClick={() => setLocationDialogOpen(true)}>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    onClick={() => setLocationDialogOpen(true)}
+                  >
                     Change Location
                   </Button>
                   <Button
@@ -291,7 +381,11 @@ const HousePage = () => {
                   >
                     Delete
                   </Button>
-                  <Button variant="link" size="sm" onClick={() => setSelectedIds([])}>
+                  <Button
+                    variant="link"
+                    size="sm"
+                    onClick={() => setSelectedIds([])}
+                  >
                     Clear
                   </Button>
                 </div>


### PR DESCRIPTION
## Summary
- add dropdown menu for downloads
- support JSON downloads alongside CSV
- update selected items download menu
- wire new JSON downloads into AllItems, CategoryPage, and HousePage

## Testing
- `npx eslint src/components/InventoryHeader.tsx src/components/filters/FilterHeader.tsx src/components/SearchFilters.tsx src/pages/CategoryPage.tsx src/pages/AllItems.tsx src/pages/HousePage.tsx --fix`
- `npx prettier -w src/components/InventoryHeader.tsx src/components/filters/FilterHeader.tsx src/components/SearchFilters.tsx src/pages/CategoryPage.tsx src/pages/AllItems.tsx src/pages/HousePage.tsx`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68715fa837588325b188b9e799eb044e