### PR TITLE
Validate new decor item fields

### DIFF
--- a/src/components/AddItemBasicInfo.tsx
+++ b/src/components/AddItemBasicInfo.tsx
@@ -17,30 +17,42 @@ export function AddItemBasicInfo({
       <h3 className="text-lg font-medium text-slate-900">Core Information</h3>
 
       <div>
-        <Label htmlFor="title">Title *</Label>
+        <Label htmlFor="code">Item Code</Label>
         <Input
-          id="title"
-          placeholder="Enter item title"
-          value={formData.title}
-          onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+          id="code"
+          placeholder="Inventory code"
+          value={formData.code}
+          onChange={(e) => setFormData({ ...formData, code: e.target.value })}
+        />
+      </div>
+
+      <div>
+        <Label htmlFor="name">Name *</Label>
+        <Input
+          id="name"
+          placeholder="Enter item name"
+          value={formData.name}
+          onChange={(e) => setFormData({ ...formData, name: e.target.value })}
           required
         />
-        {errors.title && (
-          <p className="text-destructive text-sm mt-1">{errors.title}</p>
+        {errors.name && (
+          <p className="text-destructive text-sm mt-1">{errors.name}</p>
         )}
       </div>
 
       <div>
-        <Label htmlFor="artist">Artist/Maker *</Label>
+        <Label htmlFor="creator">Creator *</Label>
         <Input
-          id="artist"
+          id="creator"
           placeholder="Artist or maker name"
-          value={formData.artist}
-          onChange={(e) => setFormData({ ...formData, artist: e.target.value })}
+          value={formData.creator}
+          onChange={(e) =>
+            setFormData({ ...formData, creator: e.target.value })
+          }
           required
         />
-        {errors.artist && (
-          <p className="text-destructive text-sm mt-1">{errors.artist}</p>
+        {errors.creator && (
+          <p className="text-destructive text-sm mt-1">{errors.creator}</p>
         )}
       </div>
 
@@ -52,9 +64,9 @@ export function AddItemBasicInfo({
             type="number"
             step="0.01"
             placeholder="0"
-            value={formData.widthCm}
+            value={formData.width_cm}
             onChange={(e) =>
-              setFormData({ ...formData, widthCm: e.target.value })
+              setFormData({ ...formData, width_cm: e.target.value })
             }
           />
         </div>
@@ -65,9 +77,9 @@ export function AddItemBasicInfo({
             type="number"
             step="0.01"
             placeholder="0"
-            value={formData.heightCm}
+            value={formData.height_cm}
             onChange={(e) =>
-              setFormData({ ...formData, heightCm: e.target.value })
+              setFormData({ ...formData, height_cm: e.target.value })
             }
           />
         </div>
@@ -78,9 +90,9 @@ export function AddItemBasicInfo({
             type="number"
             step="0.01"
             placeholder="0"
-            value={formData.depthCm}
+            value={formData.depth_cm}
             onChange={(e) =>
-              setFormData({ ...formData, depthCm: e.target.value })
+              setFormData({ ...formData, depth_cm: e.target.value })
             }
           />
         </div>
@@ -104,19 +116,72 @@ export function AddItemBasicInfo({
       </div>
 
       <div>
-        <Label htmlFor="yearPeriod">Year/Period *</Label>
+        <Label htmlFor="date_period">Date/Period *</Label>
         <Input
-          id="yearPeriod"
+          id="date_period"
           placeholder="e.g., 1920s, 2023"
-          value={formData.yearPeriod}
+          value={formData.date_period}
           onChange={(e) =>
-            setFormData({ ...formData, yearPeriod: e.target.value })
+            setFormData({ ...formData, date_period: e.target.value })
           }
           required
         />
-        {errors.yearPeriod && (
-          <p className="text-destructive text-sm mt-1">{errors.yearPeriod}</p>
+        {errors.date_period && (
+          <p className="text-destructive text-sm mt-1">{errors.date_period}</p>
         )}
+      </div>
+
+      <div>
+        <Label htmlFor="origin_region">Origin Region *</Label>
+        <Input
+          id="origin_region"
+          value={formData.origin_region}
+          onChange={(e) =>
+            setFormData({ ...formData, origin_region: e.target.value })
+          }
+          required
+        />
+        {errors.origin_region && (
+          <p className="text-destructive text-sm mt-1">
+            {errors.origin_region}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <Label htmlFor="material">Material</Label>
+        <Input
+          id="material"
+          value={formData.material}
+          onChange={(e) =>
+            setFormData({ ...formData, material: e.target.value })
+          }
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <Label htmlFor="weight_kg">Weight (kg)</Label>
+          <Input
+            id="weight_kg"
+            type="number"
+            step="0.01"
+            value={formData.weight_kg}
+            onChange={(e) =>
+              setFormData({ ...formData, weight_kg: e.target.value })
+            }
+          />
+        </div>
+        <div>
+          <Label htmlFor="provenance">Provenance</Label>
+          <Input
+            id="provenance"
+            value={formData.provenance}
+            onChange={(e) =>
+              setFormData({ ...formData, provenance: e.target.value })
+            }
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/AddItemLocationValuation.tsx
+++ b/src/components/AddItemLocationValuation.tsx
@@ -1,9 +1,18 @@
-
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Calendar } from "@/components/ui/calendar";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 import { CalendarIcon } from "lucide-react";
 import { format } from "date-fns";
@@ -15,9 +24,13 @@ interface AddItemLocationValuationProps {
   setFormData: (data: any) => void;
 }
 
-export function AddItemLocationValuation({ formData, setFormData }: AddItemLocationValuationProps) {
+export function AddItemLocationValuation({
+  formData,
+  setFormData,
+}: AddItemLocationValuationProps) {
   const handleLocationChange = (house: string, room: string) => {
-    setFormData({ ...formData, house, room });
+    const room_code = room || "";
+    setFormData({ ...formData, house, room, room_code });
   };
 
   const handleCategoryChange = (category: string, subcategory: string) => {
@@ -26,8 +39,10 @@ export function AddItemLocationValuation({ formData, setFormData }: AddItemLocat
 
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-medium text-slate-900">Category & Location</h3>
-      
+      <h3 className="text-lg font-medium text-slate-900">
+        Category & Location
+      </h3>
+
       <HierarchicalCategorySelector
         selectedCategory={formData.category}
         selectedSubcategory={formData.subcategory}
@@ -40,26 +55,30 @@ export function AddItemLocationValuation({ formData, setFormData }: AddItemLocat
         onSelectionChange={handleLocationChange}
       />
 
-
-
-      {/* Valuation Section */}
+      {/* Acquisition Section */}
       <div className="space-y-4 pt-4 border-t">
-        <h4 className="font-medium text-slate-700">Valuation Information</h4>
-        
+        <h4 className="font-medium text-slate-700">Acquisition Information</h4>
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <Label htmlFor="valuation">Valuation Amount</Label>
+            <Label htmlFor="acquisition_value">Value</Label>
             <Input
-              id="valuation"
+              id="acquisition_value"
               type="number"
               placeholder="0.00"
-              value={formData.valuation}
-              onChange={(e) => setFormData({ ...formData, valuation: e.target.value })}
+              value={formData.acquisition_value}
+              onChange={(e) =>
+                setFormData({ ...formData, acquisition_value: e.target.value })
+              }
             />
           </div>
           <div>
-            <Label htmlFor="valuationCurrency">Currency</Label>
-            <Select value={formData.valuationCurrency} onValueChange={(value) => setFormData({ ...formData, valuationCurrency: value })}>
+            <Label htmlFor="acquisition_currency">Currency</Label>
+            <Select
+              value={formData.acquisition_currency}
+              onValueChange={(value) =>
+                setFormData({ ...formData, acquisition_currency: value })
+              }
+            >
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
@@ -74,37 +93,107 @@ export function AddItemLocationValuation({ formData, setFormData }: AddItemLocat
             </Select>
           </div>
         </div>
-
         <div>
-          <Label>Valuation Date</Label>
+          <Label>Acquisition Date</Label>
           <Popover>
             <PopoverTrigger asChild>
               <Button
                 variant="outline"
-                className={`w-full justify-start text-left font-normal ${formData.valuationDate ? "" : "text-muted-foreground"}`}
+                className={`w-full justify-start text-left font-normal ${formData.acquisition_date ? "" : "text-muted-foreground"}`}
               >
                 <CalendarIcon className="mr-2 h-4 w-4" />
-                {formData.valuationDate ? format(formData.valuationDate, "PPP") : "Select date"}
+                {formData.acquisition_date
+                  ? format(formData.acquisition_date, "PPP")
+                  : "Select date"}
               </Button>
             </PopoverTrigger>
             <PopoverContent className="w-auto p-0" align="start">
               <Calendar
                 mode="single"
-                selected={formData.valuationDate}
-                onSelect={(date) => setFormData({ ...formData, valuationDate: date })}
+                selected={formData.acquisition_date}
+                onSelect={(date) =>
+                  setFormData({ ...formData, acquisition_date: date })
+                }
                 initialFocus
               />
             </PopoverContent>
           </Popover>
         </div>
+      </div>
 
+      {/* Appraisal Section */}
+      <div className="space-y-4 pt-4 border-t">
+        <h4 className="font-medium text-slate-700">Appraisal Information</h4>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="appraisal_value">Value</Label>
+            <Input
+              id="appraisal_value"
+              type="number"
+              placeholder="0.00"
+              value={formData.appraisal_value}
+              onChange={(e) =>
+                setFormData({ ...formData, appraisal_value: e.target.value })
+              }
+            />
+          </div>
+          <div>
+            <Label htmlFor="appraisal_currency">Currency</Label>
+            <Select
+              value={formData.appraisal_currency}
+              onValueChange={(value) =>
+                setFormData({ ...formData, appraisal_currency: value })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="USD">USD ($)</SelectItem>
+                <SelectItem value="EUR">EUR (€)</SelectItem>
+                <SelectItem value="GBP">GBP (£)</SelectItem>
+                <SelectItem value="JPY">JPY (¥)</SelectItem>
+                <SelectItem value="CAD">CAD ($)</SelectItem>
+                <SelectItem value="AUD">AUD ($)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
         <div>
-          <Label htmlFor="valuationPerson">Valued By</Label>
+          <Label>Appraisal Date</Label>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                className={`w-full justify-start text-left font-normal ${formData.appraisal_date ? "" : "text-muted-foreground"}`}
+              >
+                <CalendarIcon className="mr-2 h-4 w-4" />
+                {formData.appraisal_date
+                  ? format(formData.appraisal_date, "PPP")
+                  : "Select date"}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0" align="start">
+              <Calendar
+                mode="single"
+                selected={formData.appraisal_date}
+                onSelect={(date) =>
+                  setFormData({ ...formData, appraisal_date: date })
+                }
+                initialFocus
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
+        <div>
+          <Label htmlFor="appraisal_entity">Appraised By</Label>
           <Input
-            id="valuationPerson"
+            id="appraisal_entity"
             placeholder="Appraiser name or organization"
-            value={formData.valuationPerson}
-            onChange={(e) => setFormData({ ...formData, valuationPerson: e.target.value })}
+            value={formData.appraisal_entity}
+            onChange={(e) =>
+              setFormData({ ...formData, appraisal_entity: e.target.value })
+            }
           />
         </div>
       </div>

--- a/src/types/inventory.ts
+++ b/src/types/inventory.ts
@@ -1,4 +1,3 @@
-
 export interface ItemBase {
   id: number;
   title: string;
@@ -66,13 +65,50 @@ export interface MusicItem extends ItemBase {
   history?: MusicItem[];
 }
 
-export type InventoryItem = DecorItem | BookItem | MusicItem;
+export interface DecorItemInput {
+  id?: number;
+  code?: string;
+  name: string;
+  room_code: string;
+  creator: string;
+  origin_region: string;
+  date_period: string | number;
+  material?: string;
+  height_cm?: number;
+  width_cm?: number;
+  depth_cm?: number;
+  weight_kg?: number;
+  provenance?: string;
+  category: string;
+  subcategory: string;
+  quantity: number;
+  acquisition_date?: string;
+  acquisition_value?: number;
+  acquisition_currency?: string;
+  appraisal_date?: string;
+  appraisal_value?: number;
+  appraisal_currency?: string;
+  appraisal_entity?: string;
+  description?: string;
+  notes?: string;
+  version?: number;
+  is_deleted?: boolean;
+}
 
+export type InventoryItem = DecorItem | BookItem | MusicItem;
 
 export type ViewMode = "grid" | "list" | "table";
 export type CategoryFilter = "all" | string;
 export type HouseFilter = "all" | "main-house" | "guest-house" | "studio";
-export type RoomFilter = "all" | "living-room" | "bedroom" | "kitchen" | "dining-room" | "office" | "bathroom" | "hallway";
+export type RoomFilter =
+  | "all"
+  | "living-room"
+  | "bedroom"
+  | "kitchen"
+  | "dining-room"
+  | "office"
+  | "bathroom"
+  | "hallway";
 
 // Configuration types for settings
 export interface CategoryConfig {
@@ -141,9 +177,9 @@ export const categoryConfigs: CategoryConfig[] = [
       { id: "painting", name: "Painting", visible: true },
       { id: "sculpture", name: "Sculpture", visible: true },
       { id: "photography", name: "Photography", visible: true },
-      { id: "print", name: "Print", visible: true }
+      { id: "print", name: "Print", visible: true },
     ],
-    visible: true
+    visible: true,
   },
   {
     id: "furniture",
@@ -154,9 +190,9 @@ export const categoryConfigs: CategoryConfig[] = [
       { id: "table", name: "Table", visible: true },
       { id: "sofa", name: "Sofa", visible: true },
       { id: "cabinet", name: "Cabinet", visible: true },
-      { id: "rug", name: "Rug", visible: true }
+      { id: "rug", name: "Rug", visible: true },
     ],
-    visible: true
+    visible: true,
   },
   {
     id: "decorative",
@@ -165,10 +201,10 @@ export const categoryConfigs: CategoryConfig[] = [
     subcategories: [
       { id: "vase", name: "Vase", visible: true },
       { id: "mirror", name: "Mirror", visible: true },
-      { id: "lighting", name: "Lighting", visible: true }
+      { id: "lighting", name: "Lighting", visible: true },
     ],
-    visible: true
-  }
+    visible: true,
+  },
 ];
 
 // House configurations with icons
@@ -190,15 +226,64 @@ export const defaultHouses: HouseConfig[] = [
     is_deleted: false,
     icon: "house",
     rooms: [
-      { id: "living-room", name: "Living Room", floor: 1, version: 1, is_deleted: false, visible: true },
-      { id: "dining-room", name: "Dining Room", floor: 1, version: 1, is_deleted: false, visible: true },
-      { id: "kitchen", name: "Kitchen", floor: 1, version: 1, is_deleted: false, visible: true },
-      { id: "bedroom", name: "Bedroom", floor: 2, version: 1, is_deleted: false, visible: true },
-      { id: "office", name: "Office", floor: 2, version: 1, is_deleted: false, visible: true },
-      { id: "bathroom", name: "Bathroom", floor: 2, version: 1, is_deleted: false, visible: true },
-      { id: "hallway", name: "Hallway", floor: 1, version: 1, is_deleted: false, visible: true }
+      {
+        id: "living-room",
+        name: "Living Room",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "dining-room",
+        name: "Dining Room",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "kitchen",
+        name: "Kitchen",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "bedroom",
+        name: "Bedroom",
+        floor: 2,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "office",
+        name: "Office",
+        floor: 2,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "bathroom",
+        name: "Bathroom",
+        floor: 2,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "hallway",
+        name: "Hallway",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
     ],
-    visible: true
+    visible: true,
   },
   {
     id: "guest-house",
@@ -217,12 +302,40 @@ export const defaultHouses: HouseConfig[] = [
     is_deleted: false,
     icon: "house",
     rooms: [
-      { id: "living-room", name: "Living Room", floor: 1, version: 1, is_deleted: false, visible: true },
-      { id: "bedroom", name: "Bedroom", floor: 1, version: 1, is_deleted: false, visible: true },
-      { id: "kitchen", name: "Kitchen", floor: 1, version: 1, is_deleted: false, visible: true },
-      { id: "bathroom", name: "Bathroom", floor: 1, version: 1, is_deleted: false, visible: true }
+      {
+        id: "living-room",
+        name: "Living Room",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "bedroom",
+        name: "Bedroom",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "kitchen",
+        name: "Kitchen",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "bathroom",
+        name: "Bathroom",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
     ],
-    visible: true
+    visible: true,
   },
   {
     id: "studio",
@@ -241,9 +354,23 @@ export const defaultHouses: HouseConfig[] = [
     is_deleted: false,
     icon: "house",
     rooms: [
-      { id: "main-area", name: "Main Area", floor: 1, version: 1, is_deleted: false, visible: true },
-      { id: "storage", name: "Storage", floor: 1, version: 1, is_deleted: false, visible: true }
+      {
+        id: "main-area",
+        name: "Main Area",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
+      {
+        id: "storage",
+        name: "Storage",
+        floor: 1,
+        version: 1,
+        is_deleted: false,
+        visible: true,
+      },
     ],
-    visible: true
-  }
+    visible: true,
+  },
 ];


### PR DESCRIPTION
## Summary
- add new `DecorItemInput` type
- enforce required fields and conditional groups in AddItemForm
- store only allowed fields when creating/updating items
- update add item UI to capture new fields

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6871652294f48325ae46265c6afb2d1c