### PR TITLE
Remove CSV download from batch actions

### DIFF
--- a/src/pages/AllItems.tsx
+++ b/src/pages/AllItems.tsx
@@ -251,7 +251,6 @@ const AllItems = () => {
 
   const handleBatchLocation = (house: string, room: string) => {
     const ids = [...selectedIds];
-    downloadCSV();
     Promise.all(
       ids.map((id) =>
         updateDecorItem(id, { house, room } as unknown as DecorItem),
@@ -287,7 +286,6 @@ const AllItems = () => {
     )
       return;
     const ids = [...selectedIds];
-    downloadCSV();
     Promise.all(ids.map((id) => deleteDecorItem(id)))
       .then(() => {
         setItems((prev) => prev.filter((i) => !ids.includes(i.id.toString())));

--- a/src/pages/HousePage.tsx
+++ b/src/pages/HousePage.tsx
@@ -249,7 +249,6 @@ const HousePage = () => {
 
   const handleBatchLocation = (house: string, room: string) => {
     const ids = [...selectedIds];
-    downloadCSV();
     Promise.all(
       ids.map((id) =>
         updateDecorItem(id, { house, room } as unknown as DecorItem),
@@ -285,7 +284,6 @@ const HousePage = () => {
     )
       return;
     const ids = [...selectedIds];
-    downloadCSV();
     Promise.all(ids.map((id) => deleteDecorItem(id)))
       .then(() => {
         setItems((prev) => prev.filter((i) => !ids.includes(i.id.toString())));


### PR DESCRIPTION
## Summary
- prevent CSV export from running when moving or deleting items in bulk
- ran `npx eslint . --fix`, `npx prettier -w src/pages/AllItems.tsx src/pages/HousePage.tsx`, `npm run lint`, and `npm run build`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68724a3240dc8325bd6be32f619183c5