### PR TITLE
Add sidebar trigger for mobile

### DIFF
--- a/src/components/InventoryHeader.tsx
+++ b/src/components/InventoryHeader.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Plus, Download, Images } from "lucide-react";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 import { DarkModeToggle } from "@/components/DarkModeToggle";
 import { useNavigate } from "react-router-dom";
 import { useLocation } from "react-router-dom";
@@ -122,6 +123,7 @@ export function InventoryHeader() {
     <header className="border-b bg-card px-6 py-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
+          <SidebarTrigger className="md:hidden" />
           <h1 className="text-2xl font-bold text-slate-900">
             Collection Manager
           </h1>


### PR DESCRIPTION
## Summary
- add a sidebar toggle button in the header on small screens

## Testing
- `npx eslint src/components/InventoryHeader.tsx --fix`
- `npx prettier -w src/components/InventoryHeader.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68729b6081548325b9d4f0f08aea05d5