### PR TITLE
Improve new item validation

### DIFF
--- a/src/components/AddItemBasicInfo.tsx
+++ b/src/components/AddItemBasicInfo.tsx
@@ -20,9 +20,10 @@ export function AddItemBasicInfo({
         <Label htmlFor="code">Item Code</Label>
         <Input
           id="code"
-          placeholder="Inventory code"
+          placeholder="Auto-generated after save"
           value={formData.code}
-          onChange={(e) => setFormData({ ...formData, code: e.target.value })}
+          readOnly
+          disabled
         />
       </div>
 
@@ -63,7 +64,7 @@ export function AddItemBasicInfo({
             id="width"
             type="number"
             step="0.01"
-            placeholder="0"
+            placeholder="Width in cm"
             value={formData.width_cm}
             onChange={(e) =>
               setFormData({ ...formData, width_cm: e.target.value })
@@ -76,7 +77,7 @@ export function AddItemBasicInfo({
             id="height"
             type="number"
             step="0.01"
-            placeholder="0"
+            placeholder="Height in cm"
             value={formData.height_cm}
             onChange={(e) =>
               setFormData({ ...formData, height_cm: e.target.value })
@@ -89,7 +90,7 @@ export function AddItemBasicInfo({
             id="depth"
             type="number"
             step="0.01"
-            placeholder="0"
+            placeholder="Depth in cm"
             value={formData.depth_cm}
             onChange={(e) =>
               setFormData({ ...formData, depth_cm: e.target.value })
@@ -104,6 +105,7 @@ export function AddItemBasicInfo({
           id="quantity"
           type="number"
           min="1"
+          placeholder="Enter quantity"
           value={formData.quantity}
           onChange={(e) =>
             setFormData({ ...formData, quantity: e.target.value })
@@ -135,6 +137,7 @@ export function AddItemBasicInfo({
         <Label htmlFor="origin_region">Origin Region *</Label>
         <Input
           id="origin_region"
+          placeholder="Country or region"
           value={formData.origin_region}
           onChange={(e) =>
             setFormData({ ...formData, origin_region: e.target.value })
@@ -152,6 +155,7 @@ export function AddItemBasicInfo({
         <Label htmlFor="material">Material</Label>
         <Input
           id="material"
+          placeholder="e.g., wood, ceramic"
           value={formData.material}
           onChange={(e) =>
             setFormData({ ...formData, material: e.target.value })
@@ -166,6 +170,7 @@ export function AddItemBasicInfo({
             id="weight_kg"
             type="number"
             step="0.01"
+            placeholder="Weight in kg"
             value={formData.weight_kg}
             onChange={(e) =>
               setFormData({ ...formData, weight_kg: e.target.value })
@@ -176,6 +181,7 @@ export function AddItemBasicInfo({
           <Label htmlFor="provenance">Provenance</Label>
           <Input
             id="provenance"
+            placeholder="Source or previous owner"
             value={formData.provenance}
             onChange={(e) =>
               setFormData({ ...formData, provenance: e.target.value })
@@ -183,6 +189,10 @@ export function AddItemBasicInfo({
           />
         </div>
       </div>
+
+      {errors.core && (
+        <p className="text-destructive text-sm mt-1">{errors.core}</p>
+      )}
     </div>
   );
 }

--- a/src/components/AddItemDescriptionNotes.tsx
+++ b/src/components/AddItemDescriptionNotes.tsx
@@ -1,4 +1,3 @@
-
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 
@@ -7,15 +6,24 @@ interface AddItemDescriptionNotesProps {
   setFormData: (updater: (prev: any) => any) => void;
 }
 
-export function AddItemDescriptionNotes({ formData, setFormData }: AddItemDescriptionNotesProps) {
+export function AddItemDescriptionNotes({
+  formData,
+  setFormData,
+}: AddItemDescriptionNotesProps) {
   return (
     <div className="space-y-4">
+      <h3 className="text-lg font-medium text-slate-900">
+        Description &amp; Notes
+      </h3>
       <div>
         <Label htmlFor="description">Description</Label>
         <Textarea
           id="description"
+          placeholder="Detailed description of the item"
           value={formData.description}
-          onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, description: e.target.value }))
+          }
           rows={3}
         />
       </div>
@@ -24,8 +32,11 @@ export function AddItemDescriptionNotes({ formData, setFormData }: AddItemDescri
         <Label htmlFor="notes">Notes</Label>
         <Textarea
           id="notes"
+          placeholder="Any additional notes"
           value={formData.notes}
-          onChange={(e) => setFormData(prev => ({ ...prev, notes: e.target.value }))}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, notes: e.target.value }))
+          }
           rows={3}
         />
       </div>

--- a/src/components/AddItemForm.tsx
+++ b/src/components/AddItemForm.tsx
@@ -124,36 +124,15 @@ export function AddItemForm() {
     if (!formData.quantity || Number(formData.quantity) <= 0)
       newErrors.quantity = "This field is required";
 
-    const acquisitionFields = [
-      formData.acquisition_date,
-      formData.acquisition_value,
-      formData.acquisition_currency,
+    const coreFields = [
+      formData.name,
+      formData.creator,
+      formData.origin_region,
+      formData.date_period,
+      formData.quantity,
     ];
-    if (acquisitionFields.some((v) => v)) {
-      if (
-        !formData.acquisition_date ||
-        !formData.acquisition_value ||
-        !formData.acquisition_currency
-      ) {
-        newErrors.acquisition = "All acquisition fields are required";
-      }
-    }
-
-    const appraisalFields = [
-      formData.appraisal_date,
-      formData.appraisal_value,
-      formData.appraisal_currency,
-      formData.appraisal_entity,
-    ];
-    if (appraisalFields.some((v) => v)) {
-      if (
-        !formData.appraisal_date ||
-        !formData.appraisal_value ||
-        !formData.appraisal_currency ||
-        !formData.appraisal_entity
-      ) {
-        newErrors.appraisal = "All appraisal fields are required";
-      }
+    if (coreFields.some((v) => !v || !String(v).trim())) {
+      newErrors.core = "All core information fields are required";
     }
 
     if (Object.keys(newErrors).length > 0) {
@@ -288,6 +267,7 @@ export function AddItemForm() {
               <AddItemLocationValuation
                 formData={formData}
                 setFormData={setFormData}
+                errors={errors}
               />
             </div>
           </div>

--- a/src/components/AddItemLocationValuation.tsx
+++ b/src/components/AddItemLocationValuation.tsx
@@ -22,11 +22,13 @@ import { HierarchicalCategorySelector } from "@/components/HierarchicalCategoryS
 interface AddItemLocationValuationProps {
   formData: any;
   setFormData: (data: any) => void;
+  errors?: Record<string, string>;
 }
 
 export function AddItemLocationValuation({
   formData,
   setFormData,
+  errors = {},
 }: AddItemLocationValuationProps) {
   const handleLocationChange = (house: string, room: string) => {
     const room_code = room || "";
@@ -48,12 +50,20 @@ export function AddItemLocationValuation({
         selectedSubcategory={formData.subcategory}
         onSelectionChange={handleCategoryChange}
       />
+      {(errors.category || errors.subcategory) && (
+        <p className="text-destructive text-sm mt-1">
+          {errors.category || errors.subcategory}
+        </p>
+      )}
 
       <HierarchicalHouseRoomSelector
         selectedHouse={formData.house}
         selectedRoom={formData.room}
         onSelectionChange={handleLocationChange}
       />
+      {errors.room_code && (
+        <p className="text-destructive text-sm mt-1">{errors.room_code}</p>
+      )}
 
       {/* Acquisition Section */}
       <div className="space-y-4 pt-4 border-t">


### PR DESCRIPTION
## Summary
- stop requiring acquisition and appraisal fields
- show section error for Core Information when fields are missing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68729d5627248325b69b5e78e8e23575