### PR TITLE
Fix subcategory import

### DIFF
--- a/src/hooks/useSettingsState.ts
+++ b/src/hooks/useSettingsState.ts
@@ -3,6 +3,7 @@ import {
   categoryConfigs,
   defaultHouses,
   CategoryConfig,
+  SubcategoryConfig,
   HouseConfig,
   RoomConfig,
 } from "@/types/inventory";


### PR DESCRIPTION
## Summary
- import `SubcategoryConfig` into `useSettingsState.ts` for editing subcategories

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6873ff50b9d88325a71b5a492204dfe2