### PR TITLE
Add DecorItem to input conversion

### DIFF
--- a/src/lib/api/items.ts
+++ b/src/lib/api/items.ts
@@ -62,6 +62,30 @@ function convertInput(input: DecorItemInput, id: number): DecorItem {
   } as DecorItem;
 }
 
+export function decorItemToInput(item: DecorItem): DecorItemInput {
+  return {
+    id: item.id,
+    name: item.title,
+    creator: item.artist || "",
+    room_code: item.room || "",
+    origin_region: "",
+    date_period: item.yearPeriod || "",
+    width_cm: item.widthCm,
+    height_cm: item.heightCm,
+    depth_cm: item.depthCm,
+    category: item.category,
+    subcategory: item.subcategory || "",
+    quantity: item.quantity ?? 1,
+    appraisal_value: item.valuation,
+    appraisal_date: item.valuationDate,
+    appraisal_entity: item.valuationPerson,
+    appraisal_currency: item.valuationCurrency,
+    description: item.description,
+    notes: item.notes,
+    is_deleted: item.deleted,
+  } as DecorItemInput;
+}
+
 export async function fetchDecorItems(): Promise<DecorItem[]> {
   try {
     const response = await fetch(`${API_URL}/decoritems`, {

--- a/src/pages/AllItems.tsx
+++ b/src/pages/AllItems.tsx
@@ -15,6 +15,7 @@ import {
   fetchDecorItems,
   deleteDecorItem,
   restoreDecorItem,
+  decorItemToInput,
   updateDecorItem,
 } from "@/lib/api";
 import { BatchLocationDialog } from "@/components/BatchLocationDialog";
@@ -88,7 +89,7 @@ const AllItems = () => {
 
   const handleRestore = (version: DecorItem) => {
     if (!historyItem) return;
-    restoreDecorItem(historyItem.id, version)
+    restoreDecorItem(historyItem.id, decorItemToInput(version))
       .then((updated) => {
         setItems((prev) =>
           prev.map((i) => (i.id === updated.id ? updated : i)),

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -15,6 +15,7 @@ import {
   fetchDecorItems,
   deleteDecorItem,
   restoreDecorItem,
+  decorItemToInput,
   updateDecorItem,
 } from "@/lib/api";
 import { BatchLocationDialog } from "@/components/BatchLocationDialog";
@@ -90,7 +91,7 @@ const CategoryPage = () => {
 
   const handleRestore = (version: DecorItem) => {
     if (!historyItem) return;
-    restoreDecorItem(historyItem.id, version)
+    restoreDecorItem(historyItem.id, decorItemToInput(version))
       .then((updated) => {
         setItems((prev) =>
           prev.map((i) => (i.id === updated.id ? updated : i)),

--- a/src/pages/HousePage.tsx
+++ b/src/pages/HousePage.tsx
@@ -15,6 +15,7 @@ import {
   fetchDecorItems,
   deleteDecorItem,
   restoreDecorItem,
+  decorItemToInput,
   updateDecorItem,
 } from "@/lib/api";
 import { BatchLocationDialog } from "@/components/BatchLocationDialog";
@@ -90,7 +91,7 @@ const HousePage = () => {
 
   const handleRestore = (version: DecorItem) => {
     if (!historyItem) return;
-    restoreDecorItem(historyItem.id, version)
+    restoreDecorItem(historyItem.id, decorItemToInput(version))
       .then((updated) => {
         setItems((prev) =>
           prev.map((i) => (i.id === updated.id ? updated : i)),


### PR DESCRIPTION
## Summary
- add `decorItemToInput` helper for mapping `DecorItem` to `DecorItemInput`
- use the helper in AllItems, CategoryPage and HousePage before calling `restoreDecorItem`

## Testing
- `npx eslint src/lib/api/items.ts src/pages/AllItems.tsx src/pages/CategoryPage.tsx src/pages/HousePage.tsx --fix`
- `npx prettier -w src/lib/api/items.ts src/pages/AllItems.tsx src/pages/CategoryPage.tsx src/pages/HousePage.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6873ff58908c8325b1535daec9b22111