### PR TITLE
Remove code field from add/edit dialogs

### DIFF
--- a/src/components/AddItemBasicInfo.tsx
+++ b/src/components/AddItemBasicInfo.tsx
@@ -26,17 +26,6 @@ export function AddItemBasicInfo({
       </h3>
 
       <div>
-        <Label htmlFor="code">Item Code</Label>
-        <Input
-          id="code"
-          placeholder="Auto-generated after save"
-          value={formData.code}
-          readOnly
-          disabled
-        />
-      </div>
-
-      <div>
         <Label htmlFor="name">Name *</Label>
         <Input
           id="name"


### PR DESCRIPTION
## Summary
- remove the Item Code input from the add item form

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687411839b808325b4aa73a4bb771a20