### PR TITLE
Fix spacing in Category & Location section

### DIFF
--- a/src/components/AddItemLocationValuation.tsx
+++ b/src/components/AddItemLocationValuation.tsx
@@ -45,27 +45,31 @@ export function AddItemLocationValuation({
         Category & Location
       </h3>
 
-      <HierarchicalCategorySelector
-        selectedCategory={formData.category}
-        selectedSubcategory={formData.subcategory}
-        onSelectionChange={handleCategoryChange}
-        invalid={Boolean(errors.category || errors.subcategory)}
-      />
-      {(errors.category || errors.subcategory) && (
-        <p className="text-destructive text-sm mt-1">
-          {errors.category || errors.subcategory}
-        </p>
-      )}
+      <div>
+        <HierarchicalCategorySelector
+          selectedCategory={formData.category}
+          selectedSubcategory={formData.subcategory}
+          onSelectionChange={handleCategoryChange}
+          invalid={Boolean(errors.category || errors.subcategory)}
+        />
+        {(errors.category || errors.subcategory) && (
+          <p className="text-destructive text-sm mt-1">
+            {errors.category || errors.subcategory}
+          </p>
+        )}
+      </div>
 
-      <HierarchicalHouseRoomSelector
-        selectedHouse={formData.house}
-        selectedRoom={formData.room}
-        onSelectionChange={handleLocationChange}
-        invalid={Boolean(errors.room_code)}
-      />
-      {errors.room_code && (
-        <p className="text-destructive text-sm mt-1">{errors.room_code}</p>
-      )}
+      <div>
+        <HierarchicalHouseRoomSelector
+          selectedHouse={formData.house}
+          selectedRoom={formData.room}
+          onSelectionChange={handleLocationChange}
+          invalid={Boolean(errors.room_code)}
+        />
+        {errors.room_code && (
+          <p className="text-destructive text-sm mt-1">{errors.room_code}</p>
+        )}
+      </div>
 
       {/* Acquisition Section */}
       <div className="space-y-4 pt-4 border-t">


### PR DESCRIPTION
## Summary
- wrap hierarchical selectors with divs so error messages align with other sections
- ran `npm install`, `npx eslint . --fix`, `npx prettier -w .`, and `npm run build`

## Testing
- `npx eslint . --fix`
- `npx prettier -w .`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687411db20a88325ba70ff5f8d2541be