### PR TITLE
Update brand display

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -92,14 +92,12 @@ export function AppSidebar() {
         {/* Logo Section */}
         <div className="p-6 border-b border-slate-200 dark:border-slate-700">
           {!isCollapsed ? (
-            <div>
-              <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">
-                Murgenere
-              </h2>
-              <p className="text-sm text-slate-600 dark:text-slate-400">
+            <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+              Murgenere
+              <span className="block text-sm font-normal text-slate-600 dark:text-slate-400">
                 Collection Manager
-              </p>
-            </div>
+              </span>
+            </h2>
           ) : (
             <div className="text-center">
               <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">

--- a/src/components/InventoryHeader.tsx
+++ b/src/components/InventoryHeader.tsx
@@ -125,7 +125,10 @@ export function InventoryHeader() {
         <div className="flex items-center gap-4">
           <SidebarTrigger className="md:hidden" />
           <h1 className="text-2xl font-bold text-slate-900">
-            Collection Manager
+            Murgenere
+            <span className="block text-base font-normal text-slate-600">
+              Collection Manager
+            </span>
           </h1>
         </div>
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -38,8 +38,12 @@ const Login = () => {
           <div className="mx-auto w-12 h-12 bg-blue-600 rounded-lg flex items-center justify-center mb-4">
             <Package className="w-6 h-6 text-white" />
           </div>
-          <CardTitle className="text-2xl font-bold">Murgenere</CardTitle>
-          <p className="text-slate-600">Collection Manager</p>
+          <CardTitle className="text-2xl font-bold">
+            Murgenere
+            <span className="block text-sm font-normal text-slate-600">
+              Collection Manager
+            </span>
+          </CardTitle>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleLogin} className="space-y-4">


### PR DESCRIPTION
## Summary
- display brand and service together in AppSidebar
- show brand in InventoryHeader
- combine login heading and tagline
- run `npm run lint` and `npm run build`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687413e45fe88325a7b6caae20a1359a