### PR TITLE
Update brand header with dynamic service

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/components/ui/sidebar';
 import { useSidebar } from '@/components/ui/use-sidebar';
 import { useSettingsState } from '@/hooks/useSettingsState';
+import { ServiceSelect } from './ServiceSelect';
 
 const mainItems = [
   { title: 'Dashboard', url: '/', icon: Home },
@@ -99,6 +100,7 @@ export function AppSidebar() {
               <p className="text-sm text-slate-600 dark:text-slate-400">
                 Collection Manager
               </p>
+              <ServiceSelect />
             </div>
           ) : (
             <div className="text-center">

--- a/src/components/InventoryHeader.tsx
+++ b/src/components/InventoryHeader.tsx
@@ -11,10 +11,12 @@ import { DarkModeToggle } from '@/components/DarkModeToggle';
 import { useNavigate } from 'react-router-dom';
 import { useLocation } from 'react-router-dom';
 import { sampleDecorItems } from '@/data/sampleData';
+import { useService } from '@/context/ServiceContext';
 
 export function InventoryHeader() {
   const navigate = useNavigate();
   const location = useLocation();
+  const { service } = useService();
 
   const downloadCSV = async () => {
     const headers = [
@@ -125,7 +127,10 @@ export function InventoryHeader() {
         <div className="flex items-center gap-4">
           <SidebarTrigger className="md:hidden" />
           <h1 className="text-2xl font-bold text-slate-900">
-            Collection Manager
+            Murgenere
+            <span className="block text-base font-normal text-slate-600">
+              {service}
+            </span>
           </h1>
         </div>
 

--- a/src/components/ServiceSelect.tsx
+++ b/src/components/ServiceSelect.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useService } from '@/context/ServiceContext';
+
+export function ServiceSelect() {
+  const { service, setService } = useService();
+  return (
+    <Select value={service} onValueChange={setService}>
+      <SelectTrigger className="mt-2 w-full">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="Inventory">Inventory</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/context/ServiceContext.tsx
+++ b/src/context/ServiceContext.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface ServiceContextValue {
+  service: string;
+  setService: (service: string) => void;
+}
+
+const ServiceContext = React.createContext<ServiceContextValue | undefined>(
+  undefined,
+);
+
+export function ServiceProvider({ children }: { children: React.ReactNode }) {
+  const [service, setService] = React.useState('Inventory');
+  return (
+    <ServiceContext.Provider value={{ service, setService }}>
+      {children}
+    </ServiceContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useService() {
+  const context = React.useContext(ServiceContext);
+  if (!context) {
+    throw new Error('useService must be used within a ServiceProvider');
+  }
+  return context;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 import { ThemeProvider } from './components/ThemeProvider';
+import { ServiceProvider } from './context/ServiceContext';
 
 createRoot(document.getElementById('root')!).render(
   <ThemeProvider>
-    <App />
+    <ServiceProvider>
+      <App />
+    </ServiceProvider>
   </ThemeProvider>,
 );


### PR DESCRIPTION
## Summary
- keep brand and service on separate lines in sidebar and login
- add dropdown to pick service
- show chosen service in inventory header
- wrap app in service provider
- run `npm run lint` and `npm run build`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687413e45fe88325a7b6caae20a1359a