### PR TITLE
Prevent future dates on item form

### DIFF
--- a/src/components/AddItemForm.tsx
+++ b/src/components/AddItemForm.tsx
@@ -124,6 +124,13 @@ export function AddItemForm() {
     if (!formData.quantity || Number(formData.quantity) <= 0)
       newErrors.quantity = 'This field is required';
 
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (formData.acquisition_date && formData.acquisition_date > today)
+      newErrors.acquisition = 'Date cannot be in the future';
+    if (formData.appraisal_date && formData.appraisal_date > today)
+      newErrors.appraisal = 'Date cannot be in the future';
+
     if (Object.keys(newErrors).length > 0) {
       setErrors(newErrors);
       return;

--- a/src/components/AddItemLocationValuation.tsx
+++ b/src/components/AddItemLocationValuation.tsx
@@ -130,6 +130,7 @@ export function AddItemLocationValuation({
                 onSelect={(date) =>
                   setFormData({ ...formData, acquisition_date: date })
                 }
+                disabled={(date) => date > new Date()}
                 initialFocus
               />
             </PopoverContent>
@@ -201,6 +202,7 @@ export function AddItemLocationValuation({
                 onSelect={(date) =>
                   setFormData({ ...formData, appraisal_date: date })
                 }
+                disabled={(date) => date > new Date()}
                 initialFocus
               />
             </PopoverContent>


### PR DESCRIPTION
## Summary
- add validation preventing future dates in AddItemForm
- disable future date selection in AddItemLocationValuation calendar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687528491f2c8325b4938e235abe6951