### PR TITLE
Add Book and Music item types

### DIFF
--- a/src/components/ServiceSelect.tsx
+++ b/src/components/ServiceSelect.tsx
@@ -17,6 +17,8 @@ export function ServiceSelect() {
       </SelectTrigger>
       <SelectContent>
         <SelectItem value="Inventory">Inventory</SelectItem>
+        <SelectItem value="Book">Book</SelectItem>
+        <SelectItem value="Music">Music</SelectItem>
       </SelectContent>
     </Select>
   );

--- a/src/context/ServiceContext.tsx
+++ b/src/context/ServiceContext.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
+export type ServiceType = 'Inventory' | 'Book' | 'Music';
+
 interface ServiceContextValue {
-  service: string;
-  setService: (service: string) => void;
+  service: ServiceType;
+  setService: (service: ServiceType) => void;
 }
 
 const ServiceContext = React.createContext<ServiceContextValue | undefined>(
@@ -10,7 +12,7 @@ const ServiceContext = React.createContext<ServiceContextValue | undefined>(
 );
 
 export function ServiceProvider({ children }: { children: React.ReactNode }) {
-  const [service, setService] = React.useState('Inventory');
+  const [service, setService] = React.useState<ServiceType>('Inventory');
   return (
     <ServiceContext.Provider value={{ service, setService }}>
       {children}


### PR DESCRIPTION
## Summary
- extend `ServiceContext` with Book and Music service types
- populate Service dropdown with Inventory, Book and Music options

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687532fd19a88325b5150600099e088a