### PR TITLE
Add more currency options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,8 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
+        "currency-codes": "^2.2.0",
+        "currency-symbol-map": "^5.1.0",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.3.0",
         "input-otp": "^1.2.4",
@@ -4262,6 +4264,22 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/currency-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/currency-codes/-/currency-codes-2.2.0.tgz",
+      "integrity": "sha512-vpbQc5sEYHGdTVAYUhHnKv0DWiYLRvzl/KKyqeHzBh7HD/j3UlWoScpZ9tN/jG6w2feddWoObsBbaNVu5yDapg==",
+      "license": "MIT",
+      "dependencies": {
+        "first-match": "~0.0.1",
+        "nub": "~0.0.0"
+      }
+    },
+    "node_modules/currency-symbol-map": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/currency-symbol-map/-/currency-symbol-map-5.1.0.tgz",
+      "integrity": "sha512-LO/lzYRw134LMDVnLyAf1dHE5tyO6axEFkR3TXjQIOmMkAM9YL6QsiUwuXzZAmFnuDJcs4hayOgyIYtViXFrLw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -4863,6 +4881,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/first-match": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/first-match/-/first-match-0.0.1.tgz",
+      "integrity": "sha512-VvKbnaxrC0polTFDC+teKPTdl2mn6B/KUW+WB3C9RzKDeNwbzfLdnUz3FxC+tnjvus6bI0jWrWicQyVIPdS37A==",
+      "license": "MIT"
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
@@ -5957,6 +5981,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nub": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/nub/-/nub-0.0.0.tgz",
+      "integrity": "sha512-dK0Ss9C34R/vV0FfYJXuqDAqHlaW9fvWVufq9MmGF2umCuDbd5GRfRD9fpi/LiM0l4ZXf8IBB+RYmZExqCrf0w==",
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
+    "currency-codes": "^2.2.0",
+    "currency-symbol-map": "^5.1.0",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.3.0",
     "input-otp": "^1.2.4",

--- a/src/components/AddItemLocationValuation.tsx
+++ b/src/components/AddItemLocationValuation.tsx
@@ -18,6 +18,7 @@ import { CalendarIcon } from 'lucide-react';
 import { format } from 'date-fns';
 import { HierarchicalHouseRoomSelector } from '@/components/HierarchicalHouseRoomSelector';
 import { HierarchicalCategorySelector } from '@/components/HierarchicalCategorySelector';
+import { currencyOptions } from '@/data/currencies';
 
 interface AddItemLocationValuationProps {
   formData: any;
@@ -99,12 +100,11 @@ export function AddItemLocationValuation({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="USD">USD ($)</SelectItem>
-                <SelectItem value="EUR">EUR (€)</SelectItem>
-                <SelectItem value="GBP">GBP (£)</SelectItem>
-                <SelectItem value="JPY">JPY (¥)</SelectItem>
-                <SelectItem value="CAD">CAD ($)</SelectItem>
-                <SelectItem value="AUD">AUD ($)</SelectItem>
+                {currencyOptions.map(({ code, symbol }) => (
+                  <SelectItem key={code} value={code}>
+                    {code} {symbol && `(${symbol})`}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>
@@ -171,12 +171,11 @@ export function AddItemLocationValuation({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="USD">USD ($)</SelectItem>
-                <SelectItem value="EUR">EUR (€)</SelectItem>
-                <SelectItem value="GBP">GBP (£)</SelectItem>
-                <SelectItem value="JPY">JPY (¥)</SelectItem>
-                <SelectItem value="CAD">CAD ($)</SelectItem>
-                <SelectItem value="AUD">AUD ($)</SelectItem>
+                {currencyOptions.map(({ code, symbol }) => (
+                  <SelectItem key={code} value={code}>
+                    {code} {symbol && `(${symbol})`}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>

--- a/src/data/currencies.ts
+++ b/src/data/currencies.ts
@@ -1,0 +1,14 @@
+import data from 'currency-codes/data';
+import getSymbolFromCurrency from 'currency-symbol-map';
+
+export interface CurrencyOption {
+  code: string;
+  symbol: string | undefined;
+}
+
+export const currencyOptions: CurrencyOption[] = data
+  .map((item) => ({
+    code: item.code,
+    symbol: getSymbolFromCurrency(item.code) || '',
+  }))
+  .sort((a, b) => a.code.localeCompare(b.code));


### PR DESCRIPTION
## Summary
- fetch available currencies via `currency-codes` and `currency-symbol-map`
- use the dynamic list for acquisition and appraisal dropdowns
- ran `npm run lint` and `npm run build`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687532d6e9cc8325a792df26f0cd1e3e