### PR TITLE
Update banner colors to design tokens

### DIFF
--- a/src/pages/AllItems.tsx
+++ b/src/pages/AllItems.tsx
@@ -353,7 +353,7 @@ const AllItems = () => {
             />
 
             {selectedIds.length > 0 && (
-              <div className="mb-6 flex flex-wrap items-center justify-between gap-2 bg-blue-100 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 text-blue-800 dark:text-blue-100 px-4 py-2 rounded">
+              <div className="mb-6 flex flex-wrap items-center justify-between gap-2 bg-accent border border-accent text-accent-foreground px-4 py-2 rounded">
                 <span className="text-sm font-medium">
                   {selectedIds.length} item{selectedIds.length === 1 ? '' : 's'}{' '}
                   selected

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -389,7 +389,7 @@ const CategoryPage = () => {
             />
 
             {selectedIds.length > 0 && (
-              <div className="mb-6 flex flex-wrap items-center justify-between gap-2 bg-blue-100 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 text-blue-800 dark:text-blue-100 px-4 py-2 rounded">
+              <div className="mb-6 flex flex-wrap items-center justify-between gap-2 bg-accent border border-accent text-accent-foreground px-4 py-2 rounded">
                 <span className="text-sm font-medium">
                   {selectedIds.length} item{selectedIds.length === 1 ? '' : 's'}{' '}
                   selected

--- a/src/pages/HousePage.tsx
+++ b/src/pages/HousePage.tsx
@@ -362,7 +362,7 @@ const HousePage = () => {
             />
 
             {selectedIds.length > 0 && (
-              <div className="mb-6 flex flex-wrap items-center justify-between gap-2 bg-blue-100 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 text-blue-800 dark:text-blue-100 px-4 py-2 rounded">
+              <div className="mb-6 flex flex-wrap items-center justify-between gap-2 bg-accent border border-accent text-accent-foreground px-4 py-2 rounded">
                 <span className="text-sm font-medium">
                   {selectedIds.length} item{selectedIds.length === 1 ? '' : 's'}{' '}
                   selected


### PR DESCRIPTION
## Summary
- use accent tokens for selection banner background and text

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6875696777408325ba47c27a632e81f1