### PR TITLE
Fix date parsing when loading drafts

### DIFF
--- a/src/components/AddItemForm.tsx
+++ b/src/components/AddItemForm.tsx
@@ -69,10 +69,14 @@ export function AddItemForm() {
             house: draft.house || '',
             room: draft.room || '',
             room_code: draft.room_code || '',
-            acquisition_date: draft.acquisition_date || undefined,
+            acquisition_date: draft.acquisition_date
+              ? new Date(draft.acquisition_date)
+              : undefined,
             acquisition_value: draft.acquisition_value || '',
             acquisition_currency: draft.acquisition_currency || 'EUR',
-            appraisal_date: draft.appraisal_date || undefined,
+            appraisal_date: draft.appraisal_date
+              ? new Date(draft.appraisal_date)
+              : undefined,
             appraisal_value: draft.appraisal_value || '',
             appraisal_currency: draft.appraisal_currency || 'EUR',
             appraisal_entity: draft.appraisal_entity || '',


### PR DESCRIPTION
## Summary
- parse `acquisition_date` and `appraisal_date` to Date objects when loading drafts

## Testing
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_b_68756b3bffc88325b8e0a3545074c83c