### PR TITLE
Use design tokens for text colors

### DIFF
--- a/src/components/AddItemBasicInfo.tsx
+++ b/src/components/AddItemBasicInfo.tsx
@@ -16,7 +16,7 @@ export function AddItemBasicInfo({
 }: AddItemBasicInfoProps) {
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-medium text-slate-900 flex items-center">
+      <h3 className="text-lg font-medium text-foreground flex items-center">
         Core
         {errors.core && (
           <Badge variant="destructive" className="ml-2">
@@ -123,7 +123,7 @@ export function AddItemBasicInfo({
 
       {/* Physical Section */}
       <div className="space-y-4 pt-4 border-t">
-        <h3 className="text-lg font-medium text-slate-900">Physical</h3>
+        <h3 className="text-lg font-medium text-foreground">Physical</h3>
 
         <div className="grid grid-cols-3 gap-4">
           <div>

--- a/src/components/AddItemDescriptionNotes.tsx
+++ b/src/components/AddItemDescriptionNotes.tsx
@@ -12,7 +12,7 @@ export function AddItemDescriptionNotes({
 }: AddItemDescriptionNotesProps) {
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-medium text-slate-900">
+      <h3 className="text-lg font-medium text-foreground">
         Description &amp; Notes
       </h3>
       <div>

--- a/src/components/AddItemImages.tsx
+++ b/src/components/AddItemImages.tsx
@@ -120,8 +120,8 @@ export function AddItemImages({ formData, setFormData }: AddItemImagesProps) {
 
       {formData.images.length === 0 && (
         <div className="border-2 border-dashed border-slate-300 rounded-lg p-8 text-center">
-          <Image className="w-8 h-8 text-slate-400 mx-auto mb-2" />
-          <p className="text-slate-500 text-sm">No images added yet</p>
+          <Image className="w-8 h-8 text-muted-foreground mx-auto mb-2" />
+          <p className="text-muted-foreground text-sm">No images added yet</p>
         </div>
       )}
     </div>

--- a/src/components/AddItemLocationValuation.tsx
+++ b/src/components/AddItemLocationValuation.tsx
@@ -42,7 +42,7 @@ export function AddItemLocationValuation({
 
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-medium text-slate-900">
+      <h3 className="text-lg font-medium text-foreground">
         Category & Location
       </h3>
 
@@ -74,7 +74,7 @@ export function AddItemLocationValuation({
 
       {/* Acquisition Section */}
       <div className="space-y-4 pt-4 border-t">
-        <h3 className="text-lg font-medium text-slate-900">Acquisition</h3>
+        <h3 className="text-lg font-medium text-foreground">Acquisition</h3>
         <div className="grid grid-cols-2 gap-4">
           <div>
             <Label htmlFor="acquisition_value">Value</Label>
@@ -145,7 +145,7 @@ export function AddItemLocationValuation({
 
       {/* Appraisal Section */}
       <div className="space-y-4 pt-4 border-t">
-        <h3 className="text-lg font-medium text-slate-900">Appraisal</h3>
+        <h3 className="text-lg font-medium text-foreground">Appraisal</h3>
         <div className="grid grid-cols-2 gap-4">
           <div>
             <Label htmlFor="appraisal_value">Value</Label>

--- a/src/components/CsvUploader.tsx
+++ b/src/components/CsvUploader.tsx
@@ -107,7 +107,7 @@ export function CsvUploader({ onUpload }: CsvUploaderProps) {
         </div>
 
         {file && (
-          <div className="flex items-center gap-2 text-sm text-slate-600">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <FileText className="w-4 h-4" />
             {file.name}
           </div>
@@ -122,7 +122,7 @@ export function CsvUploader({ onUpload }: CsvUploaderProps) {
           Upload CSV
         </Button>
 
-        <div className="text-xs text-slate-500">
+        <div className="text-xs text-muted-foreground">
           <p>
             <strong>CSV Format Examples:</strong>
           </p>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -41,7 +41,7 @@ export function Dashboard({ items }: DashboardProps) {
       case 'furniture':
         return <Sofa className="w-8 h-8 text-dashboard-green" />;
       default:
-        return <Package className="w-8 h-8 text-slate-600" />;
+        return <Package className="w-8 h-8 text-muted-foreground" />;
     }
   };
 
@@ -53,8 +53,8 @@ export function Dashboard({ items }: DashboardProps) {
           <CardContent className="p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-slate-600">Total Items</p>
-                <p className="text-2xl font-bold text-slate-900">
+                <p className="text-sm text-muted-foreground">Total Items</p>
+                <p className="text-2xl font-bold text-foreground">
                   {totalItems}
                 </p>
               </div>
@@ -67,8 +67,8 @@ export function Dashboard({ items }: DashboardProps) {
           <CardContent className="p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-slate-600">Total Valuation</p>
-                <p className="text-2xl font-bold text-slate-900">
+                <p className="text-sm text-muted-foreground">Total Valuation</p>
+                <p className="text-2xl font-bold text-foreground">
                   ${totalValuation.toLocaleString()}
                 </p>
               </div>
@@ -86,8 +86,8 @@ export function Dashboard({ items }: DashboardProps) {
           <CardContent className="p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-slate-600">Categories</p>
-                <p className="text-2xl font-bold text-slate-900">
+                <p className="text-sm text-muted-foreground">Categories</p>
+                <p className="text-2xl font-bold text-foreground">
                   {categories.filter((c) => c.visible).length}
                 </p>
               </div>
@@ -106,7 +106,7 @@ export function Dashboard({ items }: DashboardProps) {
 
       {/* Categories */}
       <div>
-        <h2 className="text-xl font-semibold text-slate-900 mb-4">
+        <h2 className="text-xl font-semibold text-foreground mb-4">
           Browse by Category
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -121,10 +121,10 @@ export function Dashboard({ items }: DashboardProps) {
                     <div className="flex items-center gap-3">
                       {getCategoryIcon(category.id)}
                       <div>
-                        <h3 className="font-semibold text-slate-900">
+                        <h3 className="font-semibold text-foreground">
                           {category.name}
                         </h3>
-                        <p className="text-sm text-slate-600">
+                        <p className="text-sm text-muted-foreground">
                           {category.count} items
                         </p>
                       </div>
@@ -140,7 +140,7 @@ export function Dashboard({ items }: DashboardProps) {
 
       {/* Houses */}
       <div>
-        <h2 className="text-xl font-semibold text-slate-900 mb-4">
+        <h2 className="text-xl font-semibold text-foreground mb-4">
           Browse by Location
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -152,10 +152,10 @@ export function Dashboard({ items }: DashboardProps) {
                     <div className="flex items-center gap-3">
                       <Home className="w-8 h-8 text-dashboard-indigo" />
                       <div>
-                        <h3 className="font-semibold text-slate-900">
+                        <h3 className="font-semibold text-foreground">
                           {house.name}
                         </h3>
-                        <p className="text-sm text-slate-600">
+                        <p className="text-sm text-muted-foreground">
                           {house.count} items
                         </p>
                       </div>

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -3,13 +3,13 @@ import { Search } from 'lucide-react';
 export function EmptyState() {
   return (
     <div className="text-center py-12">
-      <div className="text-slate-400 mb-4">
+      <div className="text-muted-foreground mb-4">
         <Search className="w-12 h-12 mx-auto" />
       </div>
-      <h3 className="text-lg font-semibold text-slate-900 mb-2">
+      <h3 className="text-lg font-semibold text-foreground mb-2">
         No items found
       </h3>
-      <p className="text-slate-600">
+      <p className="text-muted-foreground">
         Try adjusting your search or filter criteria
       </p>
     </div>

--- a/src/components/HierarchicalCategorySelector.tsx
+++ b/src/components/HierarchicalCategorySelector.tsx
@@ -54,7 +54,7 @@ export function HierarchicalCategorySelector({
             .filter((c) => c.visible)
             .map((category) => (
               <div key={category.id}>
-                <div className="px-2 py-1 text-sm font-medium text-slate-600 bg-muted">
+                <div className="px-2 py-1 text-sm font-medium text-muted-foreground bg-muted">
                   {category.name}
                 </div>
                 <SelectItem

--- a/src/components/HierarchicalHouseRoomSelector.tsx
+++ b/src/components/HierarchicalHouseRoomSelector.tsx
@@ -53,7 +53,7 @@ export function HierarchicalHouseRoomSelector({
             .filter((h) => h.visible)
             .map((house) => (
               <div key={house.id}>
-                <div className="px-2 py-1 text-sm font-medium text-slate-600 bg-muted">
+                <div className="px-2 py-1 text-sm font-medium text-muted-foreground bg-muted">
                   {house.name}
                 </div>
                 {house.rooms

--- a/src/components/InventoryHeader.tsx
+++ b/src/components/InventoryHeader.tsx
@@ -127,7 +127,7 @@ export function InventoryHeader() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
           <SidebarTrigger className="md:hidden" />
-          <h1 className="text-2xl font-bold text-slate-900">{service}</h1>
+          <h1 className="text-2xl font-bold text-foreground">{service}</h1>
         </div>
 
         <div className="flex items-center gap-3">

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -49,30 +49,32 @@ export function ItemCard({ item, onClick, selected, onSelect }: ItemCardProps) {
         </div>
         <div className="p-4">
           <div className="flex items-start justify-between mb-2">
-            <h3 className="font-semibold text-slate-900 line-clamp-2">
+            <h3 className="font-semibold text-foreground line-clamp-2">
               {item.title}
             </h3>
           </div>
 
           {item.artist && (
-            <p className="text-slate-600 text-sm font-medium mb-1">
+            <p className="text-muted-foreground text-sm font-medium mb-1">
               by {item.artist}
             </p>
           )}
 
           {item.yearPeriod && (
-            <p className="text-slate-600 text-sm mb-2">{item.yearPeriod}</p>
+            <p className="text-muted-foreground text-sm mb-2">
+              {item.yearPeriod}
+            </p>
           )}
 
           <div className="flex items-center justify-between text-sm">
-            <div className="flex gap-2 text-xs text-slate-500">
+            <div className="flex gap-2 text-xs text-muted-foreground">
               <span className="capitalize">{item.category}</span>
               {item.subcategory && <span>• {item.subcategory}</span>}
             </div>
           </div>
 
           {(item.house || item.room) && (
-            <div className="mt-2 text-xs text-slate-500">
+            <div className="mt-2 text-xs text-muted-foreground">
               {item.house && (
                 <span className="capitalize">
                   {item.house.replace('-', ' ')}

--- a/src/components/ItemDetailDialog.tsx
+++ b/src/components/ItemDetailDialog.tsx
@@ -42,7 +42,7 @@ export function ItemDetailDialog({
         <DialogHeader>
           <DialogTitle className="text-xl font-semibold pr-16">
             {item.title}
-            <span className="block text-sm font-normal text-slate-500">
+            <span className="block text-sm font-normal text-muted-foreground">
               {item.code ?? '-'} • ID {item.id} • v{item.version ?? 1}
             </span>
           </DialogTitle>
@@ -97,72 +97,90 @@ export function ItemDetailDialog({
           <div className="grid grid-cols-2 gap-6">
             <div className="space-y-4">
               <div>
-                <h4 className="font-medium text-slate-700 mb-1">Category</h4>
-                <p className="text-slate-900 capitalize">{item.category}</p>
+                <h4 className="font-medium text-muted-foreground mb-1">
+                  Category
+                </h4>
+                <p className="text-foreground capitalize">{item.category}</p>
               </div>
 
               <div>
-                <h4 className="font-medium text-slate-700 mb-1">Subcategory</h4>
-                <p className="text-slate-900 capitalize">
+                <h4 className="font-medium text-muted-foreground mb-1">
+                  Subcategory
+                </h4>
+                <p className="text-foreground capitalize">
                   {item.subcategory ?? '-'}
                 </p>
               </div>
 
               <div>
-                <h4 className="font-medium text-slate-700 mb-1">
+                <h4 className="font-medium text-muted-foreground mb-1">
                   Artist/Maker
                 </h4>
-                <p className="text-slate-900">{item.artist ?? '-'}</p>
+                <p className="text-foreground">{item.artist ?? '-'}</p>
               </div>
 
               <div>
-                <h4 className="font-medium text-slate-700 mb-1">Year/Period</h4>
-                <p className="text-slate-900">{item.yearPeriod ?? '-'}</p>
+                <h4 className="font-medium text-muted-foreground mb-1">
+                  Year/Period
+                </h4>
+                <p className="text-foreground">{item.yearPeriod ?? '-'}</p>
               </div>
 
               <div>
-                <h4 className="font-medium text-slate-700 mb-1">
+                <h4 className="font-medium text-muted-foreground mb-1">
                   Origin Region
                 </h4>
-                <p className="text-slate-900">{item.originRegion ?? '-'}</p>
+                <p className="text-foreground">{item.originRegion ?? '-'}</p>
               </div>
 
               <div>
-                <h4 className="font-medium text-slate-700 mb-1">Material</h4>
-                <p className="text-slate-900">{item.material ?? '-'}</p>
+                <h4 className="font-medium text-muted-foreground mb-1">
+                  Material
+                </h4>
+                <p className="text-foreground">{item.material ?? '-'}</p>
               </div>
 
               <div>
-                <h4 className="font-medium text-slate-700 mb-1">Provenance</h4>
-                <p className="text-slate-900">{item.provenance ?? '-'}</p>
+                <h4 className="font-medium text-muted-foreground mb-1">
+                  Provenance
+                </h4>
+                <p className="text-foreground">{item.provenance ?? '-'}</p>
               </div>
             </div>
 
             <div className="space-y-4">
               <div>
-                <h4 className="font-medium text-slate-700 mb-1">Dimensions</h4>
-                <p className="text-slate-900">
+                <h4 className="font-medium text-muted-foreground mb-1">
+                  Dimensions
+                </h4>
+                <p className="text-foreground">
                   {item.widthCm ?? '-'} x {item.heightCm ?? '-'} x{' '}
                   {item.depthCm ?? '-'} cm
                 </p>
               </div>
 
               <div>
-                <h4 className="font-medium text-slate-700 mb-1">Weight</h4>
-                <p className="text-slate-900">{item.weightKg ?? '-'} kg</p>
+                <h4 className="font-medium text-muted-foreground mb-1">
+                  Weight
+                </h4>
+                <p className="text-foreground">{item.weightKg ?? '-'} kg</p>
               </div>
 
               <div>
-                <h4 className="font-medium text-slate-700 mb-1">Quantity</h4>
-                <p className="text-slate-900 flex items-center">
+                <h4 className="font-medium text-muted-foreground mb-1">
+                  Quantity
+                </h4>
+                <p className="text-foreground flex items-center">
                   <Hash className="w-4 h-4 mr-1" />
                   {item.quantity ?? '-'}
                 </p>
               </div>
 
               <div>
-                <h4 className="font-medium text-slate-700 mb-1">Location</h4>
-                <p className="text-slate-900 flex items-center">
+                <h4 className="font-medium text-muted-foreground mb-1">
+                  Location
+                </h4>
+                <p className="text-foreground flex items-center">
                   <MapPin className="w-4 h-4 mr-1" />
                   {item.house || item.room ? (
                     <>
@@ -190,13 +208,13 @@ export function ItemDetailDialog({
 
           {/* Acquisition Information */}
           <div className="border-t pt-4">
-            <h4 className="font-medium text-slate-700 mb-3">
+            <h4 className="font-medium text-muted-foreground mb-3">
               Acquisition Information
             </h4>
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <p className="text-sm text-slate-600">Value</p>
-                <p className="text-slate-900 flex items-center">
+                <p className="text-sm text-muted-foreground">Value</p>
+                <p className="text-foreground flex items-center">
                   <DollarSign className="w-4 h-4 mr-1" />
                   {item.acquisitionValue?.toLocaleString() ?? '-'}{' '}
                   {item.acquisitionCurrency || 'EUR'}
@@ -204,8 +222,8 @@ export function ItemDetailDialog({
               </div>
 
               <div>
-                <p className="text-sm text-slate-600">Date</p>
-                <p className="text-slate-900 flex items-center">
+                <p className="text-sm text-muted-foreground">Date</p>
+                <p className="text-foreground flex items-center">
                   <Calendar className="w-4 h-4 mr-1" />
                   {item.acquisitionDate
                     ? new Date(item.acquisitionDate).toLocaleDateString()
@@ -217,13 +235,13 @@ export function ItemDetailDialog({
 
           {/* Appraisal Information */}
           <div className="border-t pt-4">
-            <h4 className="font-medium text-slate-700 mb-3">
+            <h4 className="font-medium text-muted-foreground mb-3">
               Appraisal Information
             </h4>
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <p className="text-sm text-slate-600">Value</p>
-                <p className="text-slate-900 flex items-center">
+                <p className="text-sm text-muted-foreground">Value</p>
+                <p className="text-foreground flex items-center">
                   <DollarSign className="w-4 h-4 mr-1" />
                   {item.valuation?.toLocaleString() ?? '-'}{' '}
                   {item.valuationCurrency || 'EUR'}
@@ -231,13 +249,13 @@ export function ItemDetailDialog({
               </div>
 
               <div>
-                <p className="text-sm text-slate-600">Appraiser</p>
-                <p className="text-slate-900">{item.valuationPerson ?? '-'}</p>
+                <p className="text-sm text-muted-foreground">Appraiser</p>
+                <p className="text-foreground">{item.valuationPerson ?? '-'}</p>
               </div>
 
               <div>
-                <p className="text-sm text-slate-600">Date</p>
-                <p className="text-slate-900 flex items-center">
+                <p className="text-sm text-muted-foreground">Date</p>
+                <p className="text-foreground flex items-center">
                   <Calendar className="w-4 h-4 mr-1" />
                   {item.valuationDate
                     ? new Date(item.valuationDate).toLocaleDateString()
@@ -249,14 +267,16 @@ export function ItemDetailDialog({
 
           {/* Description */}
           <div className="border-t pt-4">
-            <h4 className="font-medium text-slate-700 mb-2">Description</h4>
-            <p className="text-slate-900">{item.description ?? '-'}</p>
+            <h4 className="font-medium text-muted-foreground mb-2">
+              Description
+            </h4>
+            <p className="text-foreground">{item.description ?? '-'}</p>
           </div>
 
           {/* Notes */}
           <div className="border-t pt-4">
-            <h4 className="font-medium text-slate-700 mb-2">Notes</h4>
-            <p className="text-slate-900">{item.notes ?? '-'}</p>
+            <h4 className="font-medium text-muted-foreground mb-2">Notes</h4>
+            <p className="text-foreground">{item.notes ?? '-'}</p>
           </div>
         </div>
       </DialogContent>

--- a/src/components/ItemsList.tsx
+++ b/src/components/ItemsList.tsx
@@ -112,7 +112,7 @@ export function ItemsList({
     <div className="space-y-4">
       {/* Sort Controls */}
       <div className="flex flex-wrap gap-2 p-4 bg-card border rounded-lg">
-        <span className="text-sm text-slate-600 mr-2">Sort by:</span>
+        <span className="text-sm text-muted-foreground mr-2">Sort by:</span>
         <SortButton field="title">Title</SortButton>
         <SortButton field="artist">Artist</SortButton>
         <SortButton field="category">Category</SortButton>
@@ -160,11 +160,11 @@ export function ItemsList({
               <div className="flex-1 space-y-2">
                 <div className="flex items-start justify-between">
                   <div>
-                    <h3 className="text-lg font-semibold text-slate-900">
+                    <h3 className="text-lg font-semibold text-foreground">
                       {item.title}
                     </h3>
                     {item.artist && (
-                      <p className="text-slate-600 text-sm font-medium">
+                      <p className="text-muted-foreground text-sm font-medium">
                         by {item.artist}
                       </p>
                     )}
@@ -180,12 +180,12 @@ export function ItemsList({
 
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
                   <div>
-                    <span className="font-medium text-slate-600">
+                    <span className="font-medium text-muted-foreground">
                       Category:
                     </span>
                     <span className="ml-2 capitalize">{item.category}</span>
                     {item.subcategory && (
-                      <span className="text-slate-500">
+                      <span className="text-muted-foreground">
                         {' '}
                         • {item.subcategory}
                       </span>
@@ -194,7 +194,7 @@ export function ItemsList({
 
                   {(item.house || item.room) && (
                     <div>
-                      <span className="font-medium text-slate-600">
+                      <span className="font-medium text-muted-foreground">
                         Location:
                       </span>
                       {item.house && (
@@ -203,7 +203,7 @@ export function ItemsList({
                         </span>
                       )}
                       {item.house && item.room && (
-                        <span className="text-slate-500"> • </span>
+                        <span className="text-muted-foreground"> • </span>
                       )}
                       {item.room && (
                         <span className="capitalize">
@@ -215,7 +215,7 @@ export function ItemsList({
 
                   {item.yearPeriod && (
                     <div>
-                      <span className="font-medium text-slate-600">
+                      <span className="font-medium text-muted-foreground">
                         Period:
                       </span>
                       <span className="ml-2">{item.yearPeriod}</span>
@@ -224,7 +224,7 @@ export function ItemsList({
 
                   {(item.widthCm || item.heightCm || item.depthCm) && (
                     <div>
-                      <span className="font-medium text-slate-600">
+                      <span className="font-medium text-muted-foreground">
                         Dimensions:
                       </span>
                       <span className="ml-2">
@@ -236,7 +236,7 @@ export function ItemsList({
 
                   {item.quantity && item.quantity > 1 && (
                     <div>
-                      <span className="font-medium text-slate-600">
+                      <span className="font-medium text-muted-foreground">
                         Quantity:
                       </span>
                       <span className="ml-2">{item.quantity}</span>
@@ -245,12 +245,12 @@ export function ItemsList({
 
                   {item.valuationDate && (
                     <div>
-                      <span className="font-medium text-slate-600">
+                      <span className="font-medium text-muted-foreground">
                         Valued:
                       </span>
                       <span className="ml-2">{item.valuationDate}</span>
                       {item.valuationPerson && (
-                        <span className="text-slate-500">
+                        <span className="text-muted-foreground">
                           {' '}
                           by {item.valuationPerson}
                         </span>
@@ -260,17 +260,19 @@ export function ItemsList({
                 </div>
 
                 {item.description && (
-                  <p className="text-slate-600 text-sm line-clamp-2">
+                  <p className="text-muted-foreground text-sm line-clamp-2">
                     {item.description}
                   </p>
                 )}
 
                 {item.notes && (
                   <div className="pt-2 border-t">
-                    <span className="font-medium text-slate-600 text-sm">
+                    <span className="font-medium text-muted-foreground text-sm">
                       Notes:
                     </span>
-                    <p className="text-slate-500 text-sm mt-1">{item.notes}</p>
+                    <p className="text-muted-foreground text-sm mt-1">
+                      {item.notes}
+                    </p>
                   </div>
                 )}
               </div>

--- a/src/components/MultiSelectFilter.tsx
+++ b/src/components/MultiSelectFilter.tsx
@@ -104,7 +104,7 @@ export function MultiSelectFilter({
               return (
                 <div
                   key={option.id}
-                  className="px-2 py-1 text-sm font-medium text-slate-600 bg-muted"
+                  className="px-2 py-1 text-sm font-medium text-muted-foreground bg-muted"
                 >
                   {option.name}
                 </div>
@@ -147,7 +147,7 @@ export function MultiSelectFilter({
                   />
                 )}
                 <span
-                  className={`text-sm ${option.header ? 'font-medium text-slate-600' : ''}`}
+                  className={`text-sm ${option.header ? 'font-medium text-muted-foreground' : ''}`}
                 >
                   {option.name}
                 </span>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -19,7 +19,7 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
       <div className="min-h-screen bg-background flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-4"></div>
-          <p className="text-slate-600">Loading...</p>
+          <p className="text-muted-foreground">Loading...</p>
         </div>
       </div>
     );

--- a/src/components/filters/AppliedFilters.tsx
+++ b/src/components/filters/AppliedFilters.tsx
@@ -104,7 +104,7 @@ export function AppliedFilters({
   return (
     <div className="bg-card p-4 rounded-lg border shadow-sm">
       <div className="flex items-center justify-between mb-3">
-        <h4 className="text-sm font-medium text-slate-700 dark:text-slate-300">
+        <h4 className="text-sm font-medium text-muted-foreground">
           Applied Filters
         </h4>
         <Button variant="ghost" size="sm" onClick={clearAllFilters}>

--- a/src/components/filters/ArtistFilter.tsx
+++ b/src/components/filters/ArtistFilter.tsx
@@ -15,7 +15,7 @@ export function ArtistFilter({
   const options = artistOptions.map((a) => ({ id: a, name: a }));
   return (
     <div>
-      <Label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+      <Label className="block text-sm font-medium text-muted-foreground mb-2">
         Artist
       </Label>
       <MultiSelectFilter

--- a/src/components/filters/CombinedCategoryFilter.tsx
+++ b/src/components/filters/CombinedCategoryFilter.tsx
@@ -134,7 +134,7 @@ export function CombinedCategoryFilter({
 
     return (
       <div className="md:col-span-2">
-        <Label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+        <Label className="block text-sm font-medium text-muted-foreground mb-2">
           Subcategories
         </Label>
         <MultiSelectFilter
@@ -149,7 +149,7 @@ export function CombinedCategoryFilter({
 
   return (
     <div className="md:col-span-2">
-      <Label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+      <Label className="block text-sm font-medium text-muted-foreground mb-2">
         Categories & Subcategories
       </Label>
       <MultiSelectFilter

--- a/src/components/filters/CombinedLocationFilter.tsx
+++ b/src/components/filters/CombinedLocationFilter.tsx
@@ -30,7 +30,7 @@ export function CombinedLocationFilter({
 
     return (
       <div className="md:col-span-2">
-        <Label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+        <Label className="block text-sm font-medium text-muted-foreground mb-2">
           Rooms
         </Label>
         <MultiSelectFilter
@@ -141,7 +141,7 @@ export function CombinedLocationFilter({
 
   return (
     <div className="md:col-span-2">
-      <Label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+      <Label className="block text-sm font-medium text-muted-foreground mb-2">
         Houses & Rooms
       </Label>
       <MultiSelectFilter

--- a/src/components/filters/FilterHeader.tsx
+++ b/src/components/filters/FilterHeader.tsx
@@ -25,7 +25,7 @@ export function FilterHeader({
 }: FilterHeaderProps) {
   return (
     <div className="flex items-center justify-between bg-card p-4 rounded-lg border shadow-sm">
-      <h3 className="text-lg font-semibold text-slate-900">
+      <h3 className="text-lg font-semibold text-foreground">
         Filter & View Options
       </h3>
       <div className="flex items-center gap-2">

--- a/src/components/filters/SearchInput.tsx
+++ b/src/components/filters/SearchInput.tsx
@@ -10,11 +10,11 @@ interface SearchInputProps {
 export function SearchInput({ searchTerm, setSearchTerm }: SearchInputProps) {
   return (
     <div className="md:col-span-2">
-      <Label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+      <Label className="block text-sm font-medium text-muted-foreground mb-2">
         Search Collection
       </Label>
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 w-4 h-4" />
+        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
         <Input
           placeholder="Search titles, descriptions, artists..."
           value={searchTerm}

--- a/src/components/filters/ValuationRangeFilter.tsx
+++ b/src/components/filters/ValuationRangeFilter.tsx
@@ -17,7 +17,7 @@ export function ValuationRangeFilter({
 }: ValuationRangeFilterProps) {
   return (
     <div>
-      <Label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+      <Label className="block text-sm font-medium text-muted-foreground mb-2">
         Valuation Range
       </Label>
       <div className="flex gap-2">

--- a/src/components/filters/YearFilter.tsx
+++ b/src/components/filters/YearFilter.tsx
@@ -16,7 +16,7 @@ export function YearFilter({
 
   return (
     <div>
-      <Label className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+      <Label className="block text-sm font-medium text-muted-foreground mb-2">
         Year/Period
       </Label>
       <MultiSelectFilter

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -24,7 +24,7 @@ const SelectTrigger = React.forwardRef<
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 text-slate-700" />
+      <ChevronDown className="h-4 w-4 text-muted-foreground" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ));

--- a/src/pages/AddItem.tsx
+++ b/src/pages/AddItem.tsx
@@ -18,10 +18,10 @@ const AddItem = () => {
 
           <main className="flex-1 p-6">
             <div className="mb-6">
-              <h2 className="text-xl font-semibold text-slate-900 mb-2">
+              <h2 className="text-xl font-semibold text-foreground mb-2">
                 {isEditMode ? 'Edit Item' : 'Add New Item'}
               </h2>
-              <p className="text-slate-600">
+              <p className="text-muted-foreground">
                 {isEditMode
                   ? 'Update details for your item'
                   : 'Add a new piece to your collection'}

--- a/src/pages/AllItems.tsx
+++ b/src/pages/AllItems.tsx
@@ -319,10 +319,10 @@ const AllItems = () => {
 
           <main className="flex-1 p-6">
             <div className="mb-6">
-              <h2 className="text-xl font-semibold text-slate-900 mb-2">
+              <h2 className="text-xl font-semibold text-foreground mb-2">
                 All Items
               </h2>
-              <p className="text-slate-600">
+              <p className="text-muted-foreground">
                 Browse and manage your entire collection
               </p>
             </div>
@@ -385,7 +385,7 @@ const AllItems = () => {
             )}
 
             <div className="mb-6">
-              <p className="text-slate-600">
+              <p className="text-muted-foreground">
                 Showing {sortedItems.length} of {items.length} items
               </p>
             </div>

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -107,10 +107,10 @@ const Analytics = () => {
 
           <main className="flex-1 p-6">
             <div className="mb-6">
-              <h2 className="text-xl font-semibold text-slate-900 mb-2">
+              <h2 className="text-xl font-semibold text-foreground mb-2">
                 Collection Analytics
               </h2>
-              <p className="text-slate-600">
+              <p className="text-muted-foreground">
                 Comprehensive overview of your collection statistics
               </p>
             </div>
@@ -119,7 +119,7 @@ const Analytics = () => {
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
               <Card>
                 <CardHeader>
-                  <CardTitle className="text-sm font-medium text-slate-600">
+                  <CardTitle className="text-sm font-medium text-muted-foreground">
                     Total Items
                   </CardTitle>
                 </CardHeader>
@@ -130,7 +130,7 @@ const Analytics = () => {
 
               <Card>
                 <CardHeader>
-                  <CardTitle className="text-sm font-medium text-slate-600">
+                  <CardTitle className="text-sm font-medium text-muted-foreground">
                     Total Valuation
                   </CardTitle>
                 </CardHeader>
@@ -143,7 +143,7 @@ const Analytics = () => {
 
               <Card>
                 <CardHeader>
-                  <CardTitle className="text-sm font-medium text-slate-600">
+                  <CardTitle className="text-sm font-medium text-muted-foreground">
                     Average Value
                   </CardTitle>
                 </CardHeader>
@@ -156,7 +156,7 @@ const Analytics = () => {
 
               <Card>
                 <CardHeader>
-                  <CardTitle className="text-sm font-medium text-slate-600">
+                  <CardTitle className="text-sm font-medium text-muted-foreground">
                     Art Pieces
                   </CardTitle>
                 </CardHeader>

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -353,10 +353,10 @@ const CategoryPage = () => {
 
           <main className="flex-1 p-6">
             <div className="mb-6">
-              <h2 className="text-xl font-semibold text-slate-900 mb-2">
+              <h2 className="text-xl font-semibold text-foreground mb-2">
                 {categoryName} Collection
               </h2>
-              <p className="text-slate-600">
+              <p className="text-muted-foreground">
                 Browse and manage your {categoryName} pieces
               </p>
             </div>
@@ -421,7 +421,7 @@ const CategoryPage = () => {
             )}
 
             <div className="mb-6">
-              <p className="text-slate-600">
+              <p className="text-muted-foreground">
                 Showing {sortedItems.length} {categoryName} pieces
               </p>
             </div>

--- a/src/pages/Drafts.tsx
+++ b/src/pages/Drafts.tsx
@@ -62,19 +62,19 @@ const Drafts = () => {
 
           <main className="flex-1 p-6">
             <div className="mb-6">
-              <h2 className="text-xl font-semibold text-slate-900 mb-2">
+              <h2 className="text-xl font-semibold text-foreground mb-2">
                 Drafts
               </h2>
-              <p className="text-slate-600">Your saved draft items</p>
+              <p className="text-muted-foreground">Your saved draft items</p>
             </div>
 
             {drafts.length === 0 ? (
               <div className="text-center py-12">
-                <FileText className="w-12 h-12 text-slate-400 mx-auto mb-4" />
-                <h3 className="text-lg font-medium text-slate-900 mb-2">
+                <FileText className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
+                <h3 className="text-lg font-medium text-foreground mb-2">
                   No drafts yet
                 </h3>
-                <p className="text-slate-600">
+                <p className="text-muted-foreground">
                   Start adding items and save them as drafts
                 </p>
               </div>
@@ -85,13 +85,13 @@ const Drafts = () => {
                     <CardContent className="p-4">
                       <div className="flex items-center justify-between">
                         <div className="flex-1">
-                          <h3 className="font-medium text-slate-900">
+                          <h3 className="font-medium text-foreground">
                             {draft.title}
                           </h3>
-                          <p className="text-sm text-slate-600 mt-1">
+                          <p className="text-sm text-muted-foreground mt-1">
                             {draft.description}
                           </p>
-                          <div className="flex gap-4 text-xs text-slate-500 mt-2">
+                          <div className="flex gap-4 text-xs text-muted-foreground mt-2">
                             <span>Last modified: {draft.lastModified}</span>
                             <span>Category: {draft.category}</span>
                             {draft.data.house && (

--- a/src/pages/HousePage.tsx
+++ b/src/pages/HousePage.tsx
@@ -329,10 +329,12 @@ const HousePage = () => {
 
           <main className="flex-1 p-6">
             <div className="mb-6">
-              <h2 className="text-xl font-semibold text-slate-900 mb-2">
+              <h2 className="text-xl font-semibold text-foreground mb-2">
                 {houseName}
               </h2>
-              <p className="text-slate-600">Items located in {houseName}</p>
+              <p className="text-muted-foreground">
+                Items located in {houseName}
+              </p>
             </div>
 
             <SearchFilters
@@ -394,7 +396,7 @@ const HousePage = () => {
             )}
 
             <div className="mb-6">
-              <p className="text-slate-600">
+              <p className="text-muted-foreground">
                 Showing {sortedItems.length} items in {houseName}
               </p>
             </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -28,10 +28,10 @@ const Index = () => {
 
           <main className="flex-1 p-6">
             <div className="mb-6">
-              <h2 className="text-xl font-semibold text-slate-900 mb-2">
+              <h2 className="text-xl font-semibold text-foreground mb-2">
                 Collection Dashboard
               </h2>
-              <p className="text-slate-600">
+              <p className="text-muted-foreground">
                 Overview of your art and furniture collection
               </p>
             </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -73,7 +73,7 @@ const Login = () => {
               {isLoading ? 'Signing in...' : 'Sign In'}
             </Button>
           </form>
-          <div className="mt-4 text-center text-sm text-slate-600">
+          <div className="mt-4 text-center text-sm text-muted-foreground">
             <p>Demo credentials:</p>
             <p>
               <strong>Username:</strong> admin

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -14,8 +14,10 @@ const NotFound = () => {
   return (
     <div className="min-h-screen flex items-center justify-center bg-background">
       <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-slate-600 mb-4">Oops! Page not found</p>
+        <h1 className="text-4xl font-bold mb-4 text-foreground">404</h1>
+        <p className="text-xl text-muted-foreground mb-4">
+          Oops! Page not found
+        </p>
         <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
           Return to Home
         </Link>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -14,10 +14,10 @@ const Settings = () => {
 
           <main className="flex-1 p-6">
             <div className="mb-6">
-              <h2 className="text-xl font-semibold text-slate-900 mb-2">
+              <h2 className="text-xl font-semibold text-foreground mb-2">
                 Settings
               </h2>
-              <p className="text-slate-600">
+              <p className="text-muted-foreground">
                 Manage your collection preferences and data structure
               </p>
             </div>


### PR DESCRIPTION
## Summary
- apply foreground variables to all headings
- use muted-foreground for paragraph text
- update icons and sort labels
- run prettier, eslint, and build

## Testing
- `npx prettier -w .`
- `npx eslint . --fix`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68756cc721e88325b0af361b109b5ee6