### PR TITLE
Display subcategory inline

### DIFF
--- a/src/components/ItemDetailDialog.tsx
+++ b/src/components/ItemDetailDialog.tsx
@@ -100,15 +100,14 @@ export function ItemDetailDialog({
                 <h4 className="font-medium text-muted-foreground mb-1">
                   Category
                 </h4>
-                <p className="text-foreground capitalize">{item.category}</p>
-              </div>
-
-              <div>
-                <h4 className="font-medium text-muted-foreground mb-1">
-                  Subcategory
-                </h4>
-                <p className="text-foreground capitalize">
-                  {item.subcategory ?? '-'}
+                <p className="text-foreground flex items-center">
+                  <span className="capitalize">{item.category}</span>
+                  {item.subcategory && (
+                    <>
+                      <span className="mx-1">•</span>
+                      <span className="capitalize">{item.subcategory}</span>
+                    </>
+                  )}
                 </p>
               </div>
 


### PR DESCRIPTION
## Summary
- display category and subcategory together in item details
- ran `npm run lint` and `npm run build`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6875756530b883258018fce5fae3ca79