### PR TITLE
addItem: load item data from storage

### DIFF
--- a/src/components/AddItemForm.tsx
+++ b/src/components/AddItemForm.tsx
@@ -63,6 +63,21 @@ export function AddItemForm() {
           draft = null;
         }
       }
+
+      if (!draft) {
+        try {
+          const inventory = JSON.parse(
+            localStorage.getItem('inventoryData') || '[]',
+          );
+          const item = inventory.find(
+            (i: DecorItem) => i.id === Number(draftId),
+          );
+          if (item) draft = decorItemToInput(item);
+        } catch {
+          draft = null;
+        }
+      }
+
       if (!draft) {
         const item = await fetchDecorItem(draftId);
         if (item) draft = decorItemToInput(item);


### PR DESCRIPTION
## Summary
- ensure `AddItemForm` loads item data from local storage before making API calls
- ran `npm run lint` and `npm run build`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6875723bb1208325adfd87c35bec3592