### PR TITLE
Ensure data loaded from API

### DIFF
--- a/src/components/CombinedCategorySelector.tsx
+++ b/src/components/CombinedCategorySelector.tsx
@@ -6,7 +6,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { categoryConfigs } from '@/types/inventory';
+import { useSettingsState } from '@/hooks/useSettingsState';
 
 interface CombinedCategorySelectorProps {
   selectedCategory: string;
@@ -19,8 +19,9 @@ export function CombinedCategorySelector({
   selectedSubcategory,
   onSelectionChange,
 }: CombinedCategorySelectorProps) {
-  // Create combined options
-  const combinedOptions = categoryConfigs.flatMap((category) =>
+  const { categories } = useSettingsState();
+
+  const combinedOptions = categories.flatMap((category) =>
     category.subcategories.map((subcategory) => ({
       value: `${category.id}|${subcategory.id}`,
       label: `${category.name} - ${subcategory.name}`,
@@ -29,8 +30,7 @@ export function CombinedCategorySelector({
     })),
   );
 
-  // Also add category-only options
-  const categoryOnlyOptions = categoryConfigs.map((category) => ({
+  const categoryOnlyOptions = categories.map((category) => ({
     value: `${category.id}|`,
     label: `${category.name} (General)`,
     categoryId: category.id,

--- a/src/components/CombinedHouseRoomSelector.tsx
+++ b/src/components/CombinedHouseRoomSelector.tsx
@@ -6,7 +6,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { defaultHouses } from '@/types/inventory';
+import { useSettingsState } from '@/hooks/useSettingsState';
 
 interface CombinedHouseRoomSelectorProps {
   selectedHouse: string;
@@ -19,8 +19,9 @@ export function CombinedHouseRoomSelector({
   selectedRoom,
   onSelectionChange,
 }: CombinedHouseRoomSelectorProps) {
-  // Create combined options
-  const combinedOptions = defaultHouses.flatMap((house) =>
+  const { houses } = useSettingsState();
+
+  const combinedOptions = houses.flatMap((house) =>
     house.rooms.map((room) => ({
       value: `${house.id}|${room.id}`,
       label: `${house.name} - ${room.name}`,

--- a/src/components/InventoryHeader.tsx
+++ b/src/components/InventoryHeader.tsx
@@ -11,9 +11,9 @@ import { DarkModeToggle } from '@/components/DarkModeToggle';
 import { LogoutButton } from '@/components/LogoutButton';
 import { useNavigate } from 'react-router-dom';
 import { useLocation } from 'react-router-dom';
-import { sampleDecorItems } from '@/data/sampleData';
 import { useService } from '@/context/ServiceContext';
 import { fetchDecorItems } from '@/lib/api';
+import type { DecorItem } from '@/types/inventory';
 import { useToast } from '@/hooks/use-toast';
 
 export function InventoryHeader() {
@@ -42,12 +42,12 @@ export function InventoryHeader() {
       'Notes',
     ];
 
-    // Use sample items as fallback if API fails
-    let items = sampleDecorItems;
+    // Fallback to an empty list if API fails
+    let items: DecorItem[] = [];
     try {
       items = await fetchDecorItems();
     } catch (err) {
-      console.error('Failed to fetch items for CSV, using sample data:', err);
+      console.error('Failed to fetch items for CSV:', err);
     }
 
     const csvContent = [
@@ -91,11 +91,11 @@ export function InventoryHeader() {
   };
 
   const downloadJSON = async () => {
-    let items = sampleDecorItems;
+    let items: DecorItem[] = [];
     try {
       items = await fetchDecorItems();
     } catch (err) {
-      console.error('Failed to fetch items for JSON, using sample data:', err);
+      console.error('Failed to fetch items for JSON:', err);
     }
 
     const jsonContent = JSON.stringify(items, null, 2);

--- a/src/hooks/useSettingsState.ts
+++ b/src/hooks/useSettingsState.ts
@@ -7,6 +7,7 @@ import {
   HouseConfig,
   RoomConfig,
 } from '@/types/inventory';
+import { fetchCategories, fetchHouses } from '@/lib/api';
 
 // Load persisted settings from localStorage if available
 let storedCategories: CategoryConfig[] | null = null;
@@ -92,6 +93,24 @@ export function useSettingsState() {
     useState<CategoryConfig[]>(globalCategories);
   const [houses, setHouses] = useState<HouseConfig[]>(globalHouses);
   const [, forceUpdate] = useState({});
+
+  useEffect(() => {
+    async function load() {
+      try {
+        globalCategories = await fetchCategories();
+      } catch {
+        // ignore
+      }
+      try {
+        globalHouses = await fetchHouses();
+      } catch {
+        // ignore
+      }
+      setCategories([...globalCategories]);
+      setHouses([...globalHouses]);
+    }
+    load();
+  }, []);
 
   useEffect(() => {
     const listener = () => {

--- a/src/lib/api/categories.ts
+++ b/src/lib/api/categories.ts
@@ -1,0 +1,226 @@
+import {
+  CategoryConfig,
+  SubcategoryConfig,
+  categoryConfigs,
+} from '@/types/inventory';
+import { API_URL, API_KEY } from './common';
+
+function buildHeaders(contentType?: string) {
+  const headers: Record<string, string> = {};
+  if (contentType) headers['Content-Type'] = contentType;
+  if (API_KEY) headers['X-API-Key'] = API_KEY;
+  return headers;
+}
+
+function getAllCategories(): CategoryConfig[] {
+  const stored = localStorage.getItem('categories');
+  if (stored) {
+    try {
+      return JSON.parse(stored) as CategoryConfig[];
+    } catch {
+      // fall through to defaults
+    }
+  }
+  localStorage.setItem('categories', JSON.stringify(categoryConfigs));
+  return [...categoryConfigs];
+}
+
+function getLocalCategories(): CategoryConfig[] {
+  return getAllCategories().filter((c) => !c.visible === false);
+}
+
+function saveLocalCategories(categories: CategoryConfig[]) {
+  localStorage.setItem('categories', JSON.stringify(categories));
+}
+
+export async function fetchCategories(): Promise<CategoryConfig[]> {
+  try {
+    const response = await fetch(`${API_URL}/categories`);
+    if (!response.ok) throw new Error('Failed to fetch categories');
+    const data = await response.json();
+    saveLocalCategories(data);
+    return data as CategoryConfig[];
+  } catch {
+    return getLocalCategories();
+  }
+}
+
+export async function createCategory(category: CategoryConfig) {
+  try {
+    const response = await fetch(`${API_URL}/categories`, {
+      method: 'POST',
+      headers: buildHeaders('application/json'),
+      body: JSON.stringify(category),
+    });
+    if (!response.ok) throw new Error('Failed to create category');
+    const data = await response.json();
+    const categories = getAllCategories();
+    saveLocalCategories([...categories, data]);
+    return data as CategoryConfig;
+  } catch {
+    const categories = getAllCategories();
+    saveLocalCategories([...categories, category]);
+    return category;
+  }
+}
+
+export async function updateCategory(
+  id: string,
+  updates: Partial<CategoryConfig>,
+) {
+  try {
+    const response = await fetch(`${API_URL}/categories/${id}`, {
+      method: 'PUT',
+      headers: buildHeaders('application/json'),
+      body: JSON.stringify(updates),
+    });
+    if (!response.ok) throw new Error('Failed to update category');
+    const data = await response.json();
+    const categories = getAllCategories().map((c) =>
+      c.id === data.id ? data : c,
+    );
+    saveLocalCategories(categories);
+    return data as CategoryConfig;
+  } catch {
+    const categories = getAllCategories().map((c) =>
+      c.id === id ? { ...c, ...updates } : c,
+    );
+    saveLocalCategories(categories);
+    return categories.find((c) => c.id === id) as CategoryConfig;
+  }
+}
+
+export async function deleteCategory(id: string) {
+  try {
+    const response = await fetch(`${API_URL}/categories/${id}`, {
+      method: 'DELETE',
+    });
+    if (!response.ok) throw new Error('Failed to delete category');
+    saveLocalCategories(getAllCategories().filter((c) => c.id !== id));
+    return true;
+  } catch {
+    saveLocalCategories(getAllCategories().filter((c) => c.id !== id));
+    return true;
+  }
+}
+
+export async function addSubcategory(
+  categoryId: string,
+  subcategory: SubcategoryConfig,
+) {
+  try {
+    const response = await fetch(
+      `${API_URL}/categories/${categoryId}/subcategories`,
+      {
+        method: 'POST',
+        headers: buildHeaders('application/json'),
+        body: JSON.stringify(subcategory),
+      },
+    );
+    if (!response.ok) throw new Error('Failed to add subcategory');
+    const data = await response.json();
+    const categories = getAllCategories().map((c) =>
+      c.id === categoryId
+        ? { ...c, subcategories: [...c.subcategories, data] }
+        : c,
+    );
+    saveLocalCategories(categories);
+    return data as SubcategoryConfig;
+  } catch {
+    const categories = getAllCategories().map((c) =>
+      c.id === categoryId
+        ? { ...c, subcategories: [...c.subcategories, subcategory] }
+        : c,
+    );
+    saveLocalCategories(categories);
+    return subcategory;
+  }
+}
+
+export async function updateSubcategory(
+  categoryId: string,
+  subcategoryId: string,
+  updates: Partial<SubcategoryConfig>,
+) {
+  try {
+    const response = await fetch(
+      `${API_URL}/categories/${categoryId}/subcategories/${subcategoryId}`,
+      {
+        method: 'PUT',
+        headers: buildHeaders('application/json'),
+        body: JSON.stringify(updates),
+      },
+    );
+    if (!response.ok) throw new Error('Failed to update subcategory');
+    const data = await response.json();
+    const categories = getAllCategories().map((c) => {
+      if (c.id === categoryId) {
+        return {
+          ...c,
+          subcategories: c.subcategories.map((s) =>
+            s.id === subcategoryId ? data : s,
+          ),
+        };
+      }
+      return c;
+    });
+    saveLocalCategories(categories);
+    return data as SubcategoryConfig;
+  } catch {
+    const categories = getAllCategories().map((c) => {
+      if (c.id === categoryId) {
+        return {
+          ...c,
+          subcategories: c.subcategories.map((s) =>
+            s.id === subcategoryId ? { ...s, ...updates } : s,
+          ),
+        };
+      }
+      return c;
+    });
+    saveLocalCategories(categories);
+    return categories
+      .find((c) => c.id === categoryId)!
+      .subcategories.find((s) => s.id === subcategoryId) as SubcategoryConfig;
+  }
+}
+
+export async function deleteSubcategory(
+  categoryId: string,
+  subcategoryId: string,
+) {
+  try {
+    const response = await fetch(
+      `${API_URL}/categories/${categoryId}/subcategories/${subcategoryId}`,
+      { method: 'DELETE' },
+    );
+    if (!response.ok) throw new Error('Failed to delete subcategory');
+    const categories = getAllCategories().map((c) =>
+      c.id === categoryId
+        ? {
+            ...c,
+            subcategories: c.subcategories.filter(
+              (s) => s.id !== subcategoryId,
+            ),
+          }
+        : c,
+    );
+    saveLocalCategories(categories);
+    return true;
+  } catch {
+    const categories = getAllCategories().map((c) =>
+      c.id === categoryId
+        ? {
+            ...c,
+            subcategories: c.subcategories.filter(
+              (s) => s.id !== subcategoryId,
+            ),
+          }
+        : c,
+    );
+    saveLocalCategories(categories);
+    return true;
+  }
+}
+
+export { getAllCategories, getLocalCategories, saveLocalCategories };

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -2,4 +2,5 @@ export * from './items';
 export * from './houses';
 export * from './rooms';
 export * from './roomTypes';
+export * from './categories';
 export * from './login';

--- a/src/pages/AllItems.tsx
+++ b/src/pages/AllItems.tsx
@@ -10,7 +10,6 @@ import { ItemsTable } from '@/components/ItemsTable';
 import { ItemDetailDialog } from '@/components/ItemDetailDialog';
 import { ItemHistoryDialog } from '@/components/ItemHistoryDialog';
 import { EmptyState } from '@/components/EmptyState';
-import { sampleDecorItems } from '@/data/sampleData';
 import {
   fetchDecorItems,
   deleteDecorItem,
@@ -41,7 +40,7 @@ const AllItems = () => {
     max?: number;
   }>({});
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
-  const [items, setItems] = useState<DecorItem[]>(sampleDecorItems);
+  const [items, setItems] = useState<DecorItem[]>([]);
   const [selectedItem, setSelectedItem] = useState<DecorItem | null>(null);
   const [historyItem, setHistoryItem] = useState<DecorItem | null>(null);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -114,7 +113,7 @@ const AllItems = () => {
   useEffect(() => {
     fetchDecorItems()
       .then((data) => setItems(data))
-      .catch(() => {});
+      .catch(() => setItems([]));
   }, []);
 
   const filteredItems = items.filter((item) => {

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -15,17 +15,16 @@ import {
   Pie,
   Cell,
 } from 'recharts';
-import { sampleDecorItems } from '@/data/sampleData';
 import { fetchDecorItems } from '@/lib/api';
 import { DecorItem } from '@/types/inventory';
 
 const Analytics = () => {
-  const [items, setItems] = useState<DecorItem[]>(sampleDecorItems);
+  const [items, setItems] = useState<DecorItem[]>([]);
 
   useEffect(() => {
     fetchDecorItems()
       .then((data) => setItems(data))
-      .catch(() => {});
+      .catch(() => setItems([]));
   }, []);
 
   // Basic statistics

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -10,7 +10,6 @@ import { ItemsTable } from '@/components/ItemsTable';
 import { ItemDetailDialog } from '@/components/ItemDetailDialog';
 import { ItemHistoryDialog } from '@/components/ItemHistoryDialog';
 import { EmptyState } from '@/components/EmptyState';
-import { sampleDecorItems } from '@/data/sampleData';
 import {
   fetchDecorItems,
   deleteDecorItem,
@@ -44,7 +43,7 @@ const CategoryPage = () => {
     max?: number;
   }>({});
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
-  const [items, setItems] = useState<DecorItem[]>(sampleDecorItems);
+  const [items, setItems] = useState<DecorItem[]>([]);
   const [selectedItem, setSelectedItem] = useState<DecorItem | null>(null);
   const [historyItem, setHistoryItem] = useState<DecorItem | null>(null);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -216,7 +215,7 @@ const CategoryPage = () => {
   useEffect(() => {
     fetchDecorItems()
       .then((data) => setItems(data))
-      .catch(() => {});
+      .catch(() => setItems([]));
   }, []);
 
   useEffect(() => {

--- a/src/pages/HousePage.tsx
+++ b/src/pages/HousePage.tsx
@@ -10,7 +10,6 @@ import { ItemsTable } from '@/components/ItemsTable';
 import { ItemDetailDialog } from '@/components/ItemDetailDialog';
 import { ItemHistoryDialog } from '@/components/ItemHistoryDialog';
 import { EmptyState } from '@/components/EmptyState';
-import { sampleDecorItems } from '@/data/sampleData';
 import {
   fetchDecorItems,
   deleteDecorItem,
@@ -43,7 +42,7 @@ const HousePage = () => {
     max?: number;
   }>({});
   const [viewMode, setViewMode] = useState<ViewMode>('grid');
-  const [items, setItems] = useState<DecorItem[]>(sampleDecorItems);
+  const [items, setItems] = useState<DecorItem[]>([]);
   const [selectedItem, setSelectedItem] = useState<DecorItem | null>(null);
   const [historyItem, setHistoryItem] = useState<DecorItem | null>(null);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -115,7 +114,7 @@ const HousePage = () => {
   useEffect(() => {
     fetchDecorItems()
       .then((data) => setItems(data))
-      .catch(() => {});
+      .catch(() => setItems([]));
   }, []);
 
   useEffect(() => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,18 +3,17 @@ import { AppSidebar } from '@/components/AppSidebar';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { InventoryHeader } from '@/components/InventoryHeader';
 import { Dashboard } from '@/components/Dashboard';
-import { sampleDecorItems } from '@/data/sampleData';
 import { fetchDecorItems } from '@/lib/api';
 import { DecorItem } from '@/types/inventory';
 
 const Index = () => {
-  const [items, setItems] = useState<DecorItem[]>(sampleDecorItems);
+  const [items, setItems] = useState<DecorItem[]>([]);
 
   useEffect(() => {
     fetchDecorItems()
       .then((data) => setItems(data))
       .catch(() => {
-        // keep sample data if request fails
+        setItems([]);
       });
   }, []);
 


### PR DESCRIPTION
## Summary
- add categories API helpers
- initialize settings from backend
- read categories and houses from settings hook
- fetch decor items on pages instead of using sample data
- drop sample data from downloads

## Testing
- `npx eslint . --fix`
- `npx prettier -w .`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68757741893c8325935d66508ff73013