### PR TITLE
Fix password icon alignment

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -69,7 +69,7 @@ const Login = () => {
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className="absolute right-1 top-1"
+                  className="absolute right-1 top-1/2 -translate-y-1/2"
                   onClick={() => setShowPassword(!showPassword)}
                 >
                   {showPassword ? (


### PR DESCRIPTION
## Summary
- center password toggle button vertically in login form

## Testing
- `npm run lint`
- `npm run build`
- `npm run dev` *(manual check)*


------
https://chatgpt.com/codex/tasks/task_b_68766b90eb6c8325a75e8883eba45ae1