### PR TITLE
Hide room code during creation

### DIFF
--- a/src/components/settings/HousesManagement.tsx
+++ b/src/components/settings/HousesManagement.tsx
@@ -116,7 +116,6 @@ export function HousesManagement({
     doors: undefined,
     description: '',
     notes: '',
-    code: '',
   });
   const [editingRoom, setEditingRoom] = useState<{
     house: HouseConfig;
@@ -200,7 +199,6 @@ export function HousesManagement({
         doors: undefined,
         description: '',
         notes: '',
-        code: '',
       });
       setShowAddRoom(null);
       setShowAddRoomValidation(false);
@@ -1022,17 +1020,6 @@ export function HousesManagement({
               />
             </div>
             <div>
-              <Label htmlFor="room-code">Room Code</Label>
-              <Input
-                id="room-code"
-                value={newRoom.code}
-                onChange={(e) =>
-                  setNewRoom({ ...newRoom, code: e.target.value })
-                }
-                placeholder="Auto-generated if empty"
-              />
-            </div>
-            <div>
               <Label>House Code</Label>
               <Input value={showAddRoom?.houseCode || ''} disabled />
               <p className="text-xs text-muted-foreground mt-1">
@@ -1236,13 +1223,7 @@ export function HousesManagement({
                   <Input
                     id="edit-room-code"
                     value={editingRoom.room.code || ''}
-                    onChange={(e) =>
-                      setEditingRoom({
-                        ...editingRoom,
-                        room: { ...editingRoom.room, code: e.target.value },
-                      })
-                    }
-                    placeholder="Auto-generated if empty"
+                    disabled
                   />
                 </div>
                 <div>


### PR DESCRIPTION
## Summary
- hide room code field when creating a room
- show room code as read only when editing
- ran `npm run lint`, `npm run build`, `npx eslint . --fix`, and `npx prettier -w .`

## Testing
- `npm run lint`
- `npm run build`
- `npx eslint . --fix`
- `npx prettier -w .`


------
https://chatgpt.com/codex/tasks/task_b_68769fb93b388325bbc978a749597c6d