### PR TITLE
Simplify category visibility check

### DIFF
--- a/src/lib/api/categories.ts
+++ b/src/lib/api/categories.ts
@@ -26,7 +26,7 @@ function getAllCategories(): CategoryConfig[] {
 }
 
 function getLocalCategories(): CategoryConfig[] {
-  return getAllCategories().filter((c) => !c.visible === false);
+  return getAllCategories().filter((c) => c.visible);
 }
 
 function saveLocalCategories(categories: CategoryConfig[]) {


### PR DESCRIPTION
## Summary
- simplify category filter to rely directly on `visible`

## Testing
- `npm run lint`
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_b_689c7ddb0b3c8325865f26bf82d0aa6b