### PR TITLE
Improve keyboard accessibility for item cards

### DIFF
--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -11,7 +11,7 @@ interface ItemCardProps {
 }
 
 export function ItemCard({ item, onClick, selected, onSelect }: ItemCardProps) {
-  const handleClick = (e: React.MouseEvent) => {
+  const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
     if (e.shiftKey && onSelect) {
       onSelect(true);
       return;
@@ -26,11 +26,14 @@ export function ItemCard({ item, onClick, selected, onSelect }: ItemCardProps) {
 
   return (
     <Card
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && handleClick(e)}
+      onClick={handleClick}
       className={cn(
         'relative group hover:shadow-lg transition-all duration-300 cursor-pointer',
         selected && 'ring-2 ring-primary',
       )}
-      onClick={handleClick}
     >
       <CardContent className="p-0">
         {onSelect && (

--- a/src/components/ItemsList.tsx
+++ b/src/components/ItemsList.tsx
@@ -128,6 +128,18 @@ export function ItemsList({
     onSelectionChange(newIds);
   };
 
+  const handleClick = (
+    e: React.MouseEvent | React.KeyboardEvent,
+    item: DecorItem,
+    idx: number,
+  ) => {
+    if (e.shiftKey) {
+      toggle(item.id.toString(), idx, true);
+    } else {
+      onItemClick?.(item);
+    }
+  };
+
   return (
     <div className="space-y-4">
       {/* Sort Controls */}
@@ -145,18 +157,17 @@ export function ItemsList({
       {sortedItems.map((item, idx) => (
         <Card
           key={item.id}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) =>
+            (e.key === 'Enter' || e.key === ' ') && handleClick(e, item, idx)
+          }
+          onClick={(e) => handleClick(e, item, idx)}
           className={cn(
             'hover:shadow-md transition-shadow cursor-pointer',
             selectedIds.includes(item.id.toString()) &&
               'ring-2 ring-primary bg-blue-50',
           )}
-          onClick={(e) => {
-            if (e.shiftKey) {
-              toggle(item.id.toString(), idx, true);
-            } else {
-              onItemClick?.(item);
-            }
-          }}
         >
           <CardContent className="p-6">
             <div className="flex gap-4">


### PR DESCRIPTION
## Summary
- add button semantics and keyboard handlers to ItemCard and ItemsList cards

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689c7de40f5083258a9d78ae33169827