### PR TITLE
pages: unify main menu headings

### DIFF
--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -191,11 +191,11 @@ const Analytics = () => {
       <div className="flex-1 flex flex-col">
         <InventoryHeader />
 
-        <main className="flex-1 p-6">
-          <div className="mb-6">
-            <h2 className="text-xl font-semibold text-foreground mb-2">
-              Collection Analytics
-            </h2>
+        <main className="flex-1 space-y-4 p-4 md:p-8 pt-6">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight text-foreground mb-2">
+              Analytics
+            </h1>
             <p className="text-muted-foreground">
               Comprehensive overview of your collection statistics
             </p>

--- a/src/pages/Drafts.tsx
+++ b/src/pages/Drafts.tsx
@@ -58,11 +58,11 @@ const Drafts = () => {
       <div className="flex-1 flex flex-col">
         <InventoryHeader />
 
-        <main className="flex-1 p-6">
-          <div className="mb-6">
-            <h2 className="text-xl font-semibold text-foreground mb-2">
+        <main className="flex-1 space-y-4 p-4 md:p-8 pt-6">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight text-foreground mb-2">
               Drafts
-            </h2>
+            </h1>
             <p className="text-muted-foreground">Your saved draft items</p>
           </div>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -19,7 +19,13 @@ const Index = () => {
       <div className="flex-1 flex flex-col">
         <InventoryHeader />
 
-        <main className="flex-1 p-4 md:p-8 pt-6">
+        <main className="flex-1 space-y-4 p-4 md:p-8 pt-6">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight text-foreground">
+              Dashboard
+            </h1>
+            <p className="text-muted-foreground">Overview of your collection</p>
+          </div>
           <Dashboard items={activeItems} />
         </main>
       </div>


### PR DESCRIPTION
## Summary
- Align Dashboard, Analytics, and Drafts pages with consistent `h1` styling
- Match spacing and structure for main menu page headers

## Testing
- `npx prettier -w src/pages/Analytics.tsx src/pages/Drafts.tsx src/pages/Index.tsx`
- `npx eslint . --fix`
- `npm run lint`
- `npm run build`
- `npm run preview`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a396bb982c8325939a3ed5b6074720