### PR TITLE
header: move theme toggle to top bar right

### DIFF
--- a/src/components/InventoryHeader.tsx
+++ b/src/components/InventoryHeader.tsx
@@ -36,7 +36,7 @@ export function InventoryHeader() {
         getTopBarClasses(),
       )}
     >
-      <div className="flex h-full items-center justify-between px-4">
+      <div className="flex h-full w-full items-center justify-between px-4">
         <div className="flex items-center gap-4">
           <SidebarTrigger />
           {showApiHealth && <ApiHealthIndicator enablePolling={true} />}

--- a/src/components/__tests__/__snapshots__/InventoryHeader.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/InventoryHeader.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`InventoryHeader visual states > renders apiwarn dark 1`] = `
     class="dark"
   >
     <header
-      class="border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 h-12 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-apiwarn)/0.15)] text-[hsl(var(--tb-fg-default))] dark:bg-[hsl(var(--tb-bg-apiwarn)/0.2)] dark:text-[hsl(var(--tb-fg-contrast))]"
+      class="topbar border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-apiwarn)/0.15)] text-[hsl(var(--tb-fg-default))] dark:bg-[hsl(var(--tb-bg-apiwarn)/0.2)] dark:text-[hsl(var(--tb-fg-contrast))]"
     >
       <div
-        class="flex h-full items-center justify-between px-4"
+        class="flex h-full w-full items-center justify-between px-4"
       >
         <div
           class="flex items-center gap-4"
@@ -31,10 +31,10 @@ exports[`InventoryHeader visual states > renders apiwarn light 1`] = `
 <DocumentFragment>
   <div>
     <header
-      class="border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 h-12 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-apiwarn)/0.15)] text-[hsl(var(--tb-fg-default))] dark:bg-[hsl(var(--tb-bg-apiwarn)/0.2)] dark:text-[hsl(var(--tb-fg-contrast))]"
+      class="topbar border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-apiwarn)/0.15)] text-[hsl(var(--tb-fg-default))] dark:bg-[hsl(var(--tb-bg-apiwarn)/0.2)] dark:text-[hsl(var(--tb-fg-contrast))]"
     >
       <div
-        class="flex h-full items-center justify-between px-4"
+        class="flex h-full w-full items-center justify-between px-4"
       >
         <div
           class="flex items-center gap-4"
@@ -58,10 +58,10 @@ exports[`InventoryHeader visual states > renders default dark 1`] = `
     class="dark"
   >
     <header
-      class="border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 h-12 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-default)/0.95)] text-[hsl(var(--tb-fg-default))]"
+      class="topbar border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-default)/0.95)] text-[hsl(var(--tb-fg-default))]"
     >
       <div
-        class="flex h-full items-center justify-between px-4"
+        class="flex h-full w-full items-center justify-between px-4"
       >
         <div
           class="flex items-center gap-4"
@@ -83,10 +83,10 @@ exports[`InventoryHeader visual states > renders default light 1`] = `
 <DocumentFragment>
   <div>
     <header
-      class="border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 h-12 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-default)/0.95)] text-[hsl(var(--tb-fg-default))]"
+      class="topbar border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-default)/0.95)] text-[hsl(var(--tb-fg-default))]"
     >
       <div
-        class="flex h-full items-center justify-between px-4"
+        class="flex h-full w-full items-center justify-between px-4"
       >
         <div
           class="flex items-center gap-4"
@@ -110,10 +110,10 @@ exports[`InventoryHeader visual states > renders testing dark 1`] = `
     class="dark"
   >
     <header
-      class="border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 h-12 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-testing)/0.15)] text-[hsl(var(--tb-fg-default))] dark:bg-[hsl(var(--tb-bg-testing)/0.2)] dark:text-[hsl(var(--tb-fg-contrast))]"
+      class="topbar border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-testing)/0.15)] text-[hsl(var(--tb-fg-default))] dark:bg-[hsl(var(--tb-bg-testing)/0.2)] dark:text-[hsl(var(--tb-fg-contrast))]"
     >
       <div
-        class="flex h-full items-center justify-between px-4"
+        class="flex h-full w-full items-center justify-between px-4"
       >
         <div
           class="flex items-center gap-4"
@@ -135,10 +135,10 @@ exports[`InventoryHeader visual states > renders testing light 1`] = `
 <DocumentFragment>
   <div>
     <header
-      class="border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 h-12 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-testing)/0.15)] text-[hsl(var(--tb-fg-default))] dark:bg-[hsl(var(--tb-bg-testing)/0.2)] dark:text-[hsl(var(--tb-fg-contrast))]"
+      class="topbar border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-testing)/0.15)] text-[hsl(var(--tb-fg-default))] dark:bg-[hsl(var(--tb-bg-testing)/0.2)] dark:text-[hsl(var(--tb-fg-contrast))]"
     >
       <div
-        class="flex h-full items-center justify-between px-4"
+        class="flex h-full w-full items-center justify-between px-4"
       >
         <div
           class="flex items-center gap-4"


### PR DESCRIPTION
## Summary
- ensure top bar container spans full width so theme toggle sits on the right
- update header snapshots

## Testing
- `npm install`
- `npx eslint . --fix`
- `npx vitest src/components/__tests__/InventoryHeader.test.tsx -u`
- `npx vitest run`
- `npm run lint`
- `npm run build`
- `npm run preview` *(server started; screenshot capture unavailable)*

------
https://chatgpt.com/codex/tasks/task_b_68a399821e0c8325ac4d22d6f1c8810d