### PR TITLE
pages: default to table view

### DIFF
--- a/src/pages/AllItems.tsx
+++ b/src/pages/AllItems.tsx
@@ -36,7 +36,7 @@ const AllItems = () => {
     min?: number;
     max?: number;
   }>({});
-  const [viewMode, setViewMode] = useState<ViewMode>('grid');
+  const [viewMode, setViewMode] = useState<ViewMode>('table');
   const [selectedItems, setSelectedItems] = useState<string[]>([]);
   const [showBatchDialog, setShowBatchDialog] = useState(false);
   const navigate = useNavigate();

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -28,7 +28,7 @@ export default function CategoryPage() {
     min?: number;
     max?: number;
   }>({});
-  const [viewMode, setViewMode] = useState<ViewMode>('grid');
+  const [viewMode, setViewMode] = useState<ViewMode>('table');
   type SortField =
     | 'title'
     | 'artist'

--- a/src/pages/HousePage.tsx
+++ b/src/pages/HousePage.tsx
@@ -28,7 +28,7 @@ export default function HousePage() {
     min?: number;
     max?: number;
   }>({});
-  const [viewMode, setViewMode] = useState<ViewMode>('grid');
+  const [viewMode, setViewMode] = useState<ViewMode>('table');
   type SortField =
     | 'title'
     | 'artist'

--- a/src/pages/Warnings.tsx
+++ b/src/pages/Warnings.tsx
@@ -35,7 +35,7 @@ const Warnings = () => {
     min?: number;
     max?: number;
   }>({});
-  const [viewMode, setViewMode] = useState<ViewMode>('grid');
+  const [viewMode, setViewMode] = useState<ViewMode>('table');
   const [searchParams, setSearchParams] = useSearchParams();
   const { houses, categories } = useSettingsState();
   type SortField =


### PR DESCRIPTION
## Summary
- set table view as default mode on Category, House, Warnings, and All Items pages

## Testing
- `npm run lint`
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_b_68a399ddcb788325bc1f5d8b8e593ddd