### PR TITLE
Show analytics filter chips and neutral test bar

### DIFF
--- a/src/components/InventoryHeader.tsx
+++ b/src/components/InventoryHeader.tsx
@@ -11,11 +11,6 @@ export function InventoryHeader() {
 
   const getTopBarClasses = () => {
     switch (topBarState) {
-      case 'testing':
-        return cn(
-          'bg-[hsl(var(--tb-bg-testing)/0.15)] text-[hsl(var(--tb-fg-default))]',
-          'dark:bg-[hsl(var(--tb-bg-testing)/0.2)] dark:text-[hsl(var(--tb-fg-contrast))]',
-        );
       case 'apiwarn':
         return cn(
           'bg-[hsl(var(--tb-bg-apiwarn)/0.15)] text-[hsl(var(--tb-fg-default))]',

--- a/src/components/__tests__/__snapshots__/InventoryHeader.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/InventoryHeader.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`InventoryHeader visual states > renders testing dark 1`] = `
     class="dark"
   >
     <header
-      class="topbar border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-testing)/0.15)] text-[hsl(var(--tb-fg-default))] dark:bg-[hsl(var(--tb-bg-testing)/0.2)] dark:text-[hsl(var(--tb-fg-contrast))]"
+      class="topbar border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-default)/0.95)] text-[hsl(var(--tb-fg-default))]"
     >
       <div
         class="flex h-full w-full items-center justify-between px-4"
@@ -135,7 +135,7 @@ exports[`InventoryHeader visual states > renders testing light 1`] = `
 <DocumentFragment>
   <div>
     <header
-      class="topbar border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-testing)/0.15)] text-[hsl(var(--tb-fg-default))] dark:bg-[hsl(var(--tb-bg-testing)/0.2)] dark:text-[hsl(var(--tb-fg-contrast))]"
+      class="topbar border-b backdrop-blur supports-[backdrop-filter]:bg-background/60 sticky top-0 z-40 border-[hsl(var(--tb-border))] bg-[hsl(var(--tb-bg-default)/0.95)] text-[hsl(var(--tb-fg-default))]"
     >
       <div
         class="flex h-full w-full items-center justify-between px-4"

--- a/src/components/analytics/AnalyticsFilters.tsx
+++ b/src/components/analytics/AnalyticsFilters.tsx
@@ -1,7 +1,7 @@
-
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { MultiSelectFilter } from '@/components/MultiSelectFilter';
 import { DecorItem } from '@/types/inventory';
+import { AppliedAnalyticsFilters } from './AppliedAnalyticsFilters';
+import { cn } from '@/lib/utils';
 
 interface AnalyticsFiltersProps {
   items: DecorItem[];
@@ -22,74 +22,69 @@ export function AnalyticsFilters({
   selectedCurrencies,
   setSelectedCurrencies,
 }: AnalyticsFiltersProps) {
-  // Get unique categories
   const categories = Array.from(
-    new Set(items.map(item => item.category))
-  ).map(category => ({
+    new Set(items.map((item) => item.category)),
+  ).map((category) => ({
     id: category,
     name: category.charAt(0).toUpperCase() + category.slice(1),
   }));
 
-  // Get unique houses
   const houses = Array.from(
-    new Set(items.map(item => item.house).filter(Boolean))
-  ).map(house => ({
+    new Set(items.map((item) => item.house).filter(Boolean)),
+  ).map((house) => ({
     id: house!,
     name: house!.replace('-', ' ').replace(/\b\w/g, (l) => l.toUpperCase()),
   }));
 
-  // Get unique currencies
   const currencies = Array.from(
-    new Set(items.map(item => item.valuationCurrency).filter(Boolean))
-  ).map(currency => ({
-    id: currency!,
-    name: currency!,
-  }));
+    new Set(items.map((item) => item.valuationCurrency).filter(Boolean)),
+  ).map((currency) => ({ id: currency!, name: currency! }));
+
+  const activeCount =
+    selectedCategories.length +
+    selectedHouses.length +
+    selectedCurrencies.length;
 
   return (
-    <Card className="mb-8">
-      <CardHeader>
-        <CardTitle>Filters</CardTitle>
-      </CardHeader>
-      <CardContent>
+    <div className="mb-8 space-y-6">
+      <div
+        className={cn(
+          'bg-card p-4 rounded-lg border shadow-sm',
+          activeCount > 0 && 'border-primary',
+        )}
+      >
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div>
-            <label className="block text-sm font-medium text-muted-foreground mb-2">
-              Categories
-            </label>
-            <MultiSelectFilter
-              placeholder="Select categories"
-              options={categories}
-              selectedValues={selectedCategories}
-              onSelectionChange={setSelectedCategories}
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-muted-foreground mb-2">
-              Houses
-            </label>
-            <MultiSelectFilter
-              placeholder="Select houses"
-              options={houses}
-              selectedValues={selectedHouses}
-              onSelectionChange={setSelectedHouses}
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-muted-foreground mb-2">
-              Currencies
-            </label>
-            <MultiSelectFilter
-              placeholder="Select currencies"
-              options={currencies}
-              selectedValues={selectedCurrencies}
-              onSelectionChange={setSelectedCurrencies}
-            />
-          </div>
+          <MultiSelectFilter
+            placeholder="Select categories"
+            options={categories}
+            selectedValues={selectedCategories}
+            onSelectionChange={setSelectedCategories}
+          />
+          <MultiSelectFilter
+            placeholder="Select houses"
+            options={houses}
+            selectedValues={selectedHouses}
+            onSelectionChange={setSelectedHouses}
+          />
+          <MultiSelectFilter
+            placeholder="Select currencies"
+            options={currencies}
+            selectedValues={selectedCurrencies}
+            onSelectionChange={setSelectedCurrencies}
+          />
         </div>
-      </CardContent>
-    </Card>
+      </div>
+      <AppliedAnalyticsFilters
+        selectedCategories={selectedCategories}
+        setSelectedCategories={setSelectedCategories}
+        selectedHouses={selectedHouses}
+        setSelectedHouses={setSelectedHouses}
+        selectedCurrencies={selectedCurrencies}
+        setSelectedCurrencies={setSelectedCurrencies}
+        categoryOptions={categories}
+        houseOptions={houses}
+        currencyOptions={currencies}
+      />
+    </div>
   );
 }

--- a/src/components/analytics/AppliedAnalyticsFilters.tsx
+++ b/src/components/analytics/AppliedAnalyticsFilters.tsx
@@ -1,0 +1,106 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { X } from 'lucide-react';
+
+interface Option {
+  id: string;
+  name: string;
+}
+
+interface AppliedAnalyticsFiltersProps {
+  selectedCategories: string[];
+  setSelectedCategories: (categories: string[]) => void;
+  selectedHouses: string[];
+  setSelectedHouses: (houses: string[]) => void;
+  selectedCurrencies: string[];
+  setSelectedCurrencies: (currencies: string[]) => void;
+  categoryOptions: Option[];
+  houseOptions: Option[];
+  currencyOptions: Option[];
+}
+
+export function AppliedAnalyticsFilters({
+  selectedCategories,
+  setSelectedCategories,
+  selectedHouses,
+  setSelectedHouses,
+  selectedCurrencies,
+  setSelectedCurrencies,
+  categoryOptions,
+  houseOptions,
+  currencyOptions,
+}: AppliedAnalyticsFiltersProps) {
+  const hasFilters =
+    selectedCategories.length > 0 ||
+    selectedHouses.length > 0 ||
+    selectedCurrencies.length > 0;
+
+  const clearAll = () => {
+    setSelectedCategories([]);
+    setSelectedHouses([]);
+    setSelectedCurrencies([]);
+  };
+
+  if (!hasFilters) return null;
+
+  return (
+    <div className="bg-card p-4 rounded-lg border shadow-sm">
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-sm font-medium text-muted-foreground">
+          Applied Filters
+        </h4>
+        <Button variant="ghost" size="sm" onClick={clearAll}>
+          Clear All
+        </Button>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {selectedCategories.map((id) => {
+          const category = categoryOptions.find((c) => c.id === id);
+          return (
+            <Badge key={id} variant="default" className="px-3 py-1">
+              Category: {category?.name || id}
+              <X
+                className="w-3 h-3 ml-2 cursor-pointer hover:text-destructive"
+                onClick={() =>
+                  setSelectedCategories(
+                    selectedCategories.filter((c) => c !== id),
+                  )
+                }
+              />
+            </Badge>
+          );
+        })}
+        {selectedHouses.map((id) => {
+          const house = houseOptions.find((h) => h.id === id);
+          return (
+            <Badge key={id} variant="default" className="px-3 py-1">
+              House: {house?.name || id}
+              <X
+                className="w-3 h-3 ml-2 cursor-pointer hover:text-destructive"
+                onClick={() =>
+                  setSelectedHouses(selectedHouses.filter((h) => h !== id))
+                }
+              />
+            </Badge>
+          );
+        })}
+        {selectedCurrencies.map((id) => {
+          const currency = currencyOptions.find((c) => c.id === id);
+          return (
+            <Badge key={id} variant="secondary" className="px-3 py-1">
+              Currency: {currency?.name || id}
+              <X
+                className="w-3 h-3 ml-2 cursor-pointer hover:text-destructive"
+                onClick={() =>
+                  setSelectedCurrencies(
+                    selectedCurrencies.filter((c) => c !== id),
+                  )
+                }
+              />
+            </Badge>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -763,5 +763,7 @@ export {
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
-  useSidebar,
 };
+
+// eslint-disable-next-line react-refresh/only-export-components
+export { useSidebar };

--- a/src/context/TestDataProvider.tsx
+++ b/src/context/TestDataProvider.tsx
@@ -29,6 +29,7 @@ export function TestDataProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useTesting() {
   const ctx = useContext(TestDataContext);
   if (!ctx) throw new Error('useTesting must be used within TestDataProvider');

--- a/src/index.css
+++ b/src/index.css
@@ -66,7 +66,6 @@ All colors MUST be HSL.
 
     /* Top bar semantic tokens */
     --tb-bg-default: var(--background);
-    --tb-bg-testing: var(--destructive);
     --tb-bg-apiwarn: 38 92% 50%;
     --tb-fg-default: var(--foreground);
     --tb-fg-contrast: var(--primary-foreground);

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { InventoryHeader } from '@/components/InventoryHeader';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -34,6 +35,24 @@ const Analytics = () => {
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [selectedHouses, setSelectedHouses] = useState<string[]>([]);
   const [selectedCurrencies, setSelectedCurrencies] = useState<string[]>([]);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    const categoriesParam = searchParams.get('categories');
+    const housesParam = searchParams.get('houses');
+    const currenciesParam = searchParams.get('currencies');
+
+    if (categoriesParam) {
+      setSelectedCategories(categoriesParam.split(',').filter(Boolean));
+    }
+    if (housesParam) {
+      setSelectedHouses(housesParam.split(',').filter(Boolean));
+    }
+    if (currenciesParam) {
+      setSelectedCurrencies(currenciesParam.split(',').filter(Boolean));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     fetchDecorItems()
@@ -73,6 +92,20 @@ const Analytics = () => {
 
     setFilteredItems(filtered);
   }, [items, selectedCategories, selectedHouses, selectedCurrencies]);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (selectedCategories.length > 0) {
+      params.set('categories', selectedCategories.join(','));
+    }
+    if (selectedHouses.length > 0) {
+      params.set('houses', selectedHouses.join(','));
+    }
+    if (selectedCurrencies.length > 0) {
+      params.set('currencies', selectedCurrencies.join(','));
+    }
+    setSearchParams(params, { replace: true });
+  }, [selectedCategories, selectedHouses, selectedCurrencies, setSearchParams]);
 
   // Basic statistics
   const totalItems = filteredItems.length;


### PR DESCRIPTION
## Summary
- replace collection analytics filters with chip-based component
- sync analytics filters to URL params for shareable views
- keep top bar neutral in test mode

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b340d7af588325b1b135bf7fbc8b4b