### PR TITLE
Ensure list fetches send API key header

### DIFF
--- a/src/lib/api/categories.ts
+++ b/src/lib/api/categories.ts
@@ -35,7 +35,9 @@ function saveLocalCategories(categories: CategoryConfig[]) {
 
 export async function fetchCategories(): Promise<CategoryConfig[]> {
   try {
-    const response = await fetch(`${API_URL}/categories`);
+    const response = await fetch(`${API_URL}/categories`, {
+      headers: buildHeaders(),
+    });
     if (!response.ok) throw new Error('Failed to fetch categories');
     const data = await response.json();
     saveLocalCategories(data);

--- a/src/lib/api/houses.ts
+++ b/src/lib/api/houses.ts
@@ -31,7 +31,9 @@ function saveLocalHouses(houses: HouseConfig[]) {
 
 export async function fetchHouses(): Promise<HouseConfig[]> {
   try {
-    const response = await fetch(`${API_URL}/houses`);
+    const response = await fetch(`${API_URL}/houses`, {
+      headers: buildHeaders(),
+    });
     if (!response.ok) throw new Error('Failed to fetch houses');
     const data = await response.json();
     saveLocalHouses(data);


### PR DESCRIPTION
## Summary
- ensure the list fetch helpers for houses and categories reuse buildHeaders so the API key header is sent when configured
- retain the existing error handling and localStorage fallback logic

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ca83d3f9e48325a5a21140160d3647