### PR TITLE
feat: introduce shared hierarchical selector

### DIFF
--- a/src/components/HierarchicalCategorySelector.tsx
+++ b/src/components/HierarchicalCategorySelector.tsx
@@ -1,12 +1,4 @@
-import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { cn } from '@/lib/utils';
+import { HierarchicalSelector } from '@/components/HierarchicalSelector';
 import { useSettingsState } from '@/hooks/useSettingsState';
 
 interface HierarchicalCategorySelectorProps {
@@ -24,60 +16,24 @@ export function HierarchicalCategorySelector({
 }: HierarchicalCategorySelectorProps) {
   const { categories } = useSettingsState();
 
-  const currentValue = selectedCategory
-    ? `${selectedCategory}|${selectedSubcategory || ''}`
-    : '';
-
-  const handleSelectionChange = (value: string) => {
-    if (value) {
-      const [categoryId, subcategoryId] = value.split('|');
-      onSelectionChange(categoryId, subcategoryId || '');
-    } else {
-      onSelectionChange('', '');
-    }
-  };
-
   return (
-    <div>
-      <Label htmlFor="categorySubcategory">Category *</Label>
-      <Select value={currentValue} onValueChange={handleSelectionChange}>
-        <SelectTrigger
-          className={cn(
-            currentValue ? undefined : 'text-muted-foreground',
-            invalid && 'border-destructive focus:ring-destructive',
-          )}
-        >
-          <SelectValue placeholder="Select category and subcategory" />
-        </SelectTrigger>
-        <SelectContent>
-          {categories
-            .filter((c) => c.visible)
-            .map((category) => (
-              <div key={category.id}>
-                <div className="px-2 py-1 text-sm font-medium text-muted-foreground bg-muted">
-                  {category.name}
-                </div>
-                <SelectItem
-                  value={`${category.id}|`}
-                  className="pl-6 font-medium"
-                >
-                  General {category.name}
-                </SelectItem>
-                {category.subcategories
-                  .filter((s) => s.visible)
-                  .map((subcategory) => (
-                    <SelectItem
-                      key={`${category.id}|${subcategory.id}`}
-                      value={`${category.id}|${subcategory.id}`}
-                      className="pl-6"
-                    >
-                      {subcategory.name}
-                    </SelectItem>
-                  ))}
-              </div>
-            ))}
-        </SelectContent>
-      </Select>
-    </div>
+    <HierarchicalSelector
+      label="Category *"
+      labelFor="categorySubcategory"
+      placeholder="Select category and subcategory"
+      parents={categories}
+      selectedParent={selectedCategory}
+      selectedChild={selectedSubcategory}
+      onSelectionChange={onSelectionChange}
+      getChildren={(category) => category.subcategories}
+      getParentId={(category) => category.id}
+      getParentName={(category) => category.name}
+      getChildId={(subcategory) => subcategory.id}
+      getChildName={(subcategory) => subcategory.name}
+      invalid={invalid}
+      includeGeneralOption
+      isParentVisible={(category) => Boolean(category.visible)}
+      isChildVisible={(subcategory) => Boolean(subcategory.visible)}
+    />
   );
 }

--- a/src/components/HierarchicalHouseRoomSelector.tsx
+++ b/src/components/HierarchicalHouseRoomSelector.tsx
@@ -1,13 +1,5 @@
-import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { HierarchicalSelector } from '@/components/HierarchicalSelector';
 import { useSettingsState } from '@/hooks/useSettingsState';
-import { cn } from '@/lib/utils';
 
 interface HierarchicalHouseRoomSelectorProps {
   selectedHouse: string;
@@ -24,53 +16,24 @@ export function HierarchicalHouseRoomSelector({
 }: HierarchicalHouseRoomSelectorProps) {
   const { houses } = useSettingsState();
 
-  const currentValue =
-    selectedHouse && selectedRoom ? `${selectedHouse}|${selectedRoom}` : '';
-
-  const handleSelectionChange = (value: string) => {
-    if (value) {
-      const [houseId, roomId] = value.split('|');
-      onSelectionChange(houseId, roomId);
-    } else {
-      onSelectionChange('', '');
-    }
-  };
-
   return (
-    <div>
-      <Label htmlFor="houseRoom">Location (House - Room) *</Label>
-      <Select value={currentValue} onValueChange={handleSelectionChange}>
-        <SelectTrigger
-          className={cn(
-            currentValue ? undefined : 'text-muted-foreground',
-            invalid && 'border-destructive focus:ring-destructive',
-          )}
-        >
-          <SelectValue placeholder="Select house and room" />
-        </SelectTrigger>
-        <SelectContent>
-          {houses
-            .filter((h) => h.visible)
-            .map((house) => (
-              <div key={house.id}>
-                <div className="px-2 py-1 text-sm font-medium text-muted-foreground bg-muted">
-                  {house.name}
-                </div>
-                {house.rooms
-                  .filter((r) => r.visible)
-                  .map((room) => (
-                    <SelectItem
-                      key={`${house.id}|${room.id}`}
-                      value={`${house.id}|${room.id}`}
-                      className="pl-6"
-                    >
-                      {room.name}
-                    </SelectItem>
-                  ))}
-              </div>
-            ))}
-        </SelectContent>
-      </Select>
-    </div>
+    <HierarchicalSelector
+      label="Location (House - Room) *"
+      labelFor="houseRoom"
+      placeholder="Select house and room"
+      parents={houses}
+      selectedParent={selectedHouse}
+      selectedChild={selectedRoom}
+      onSelectionChange={onSelectionChange}
+      getChildren={(house) => house.rooms}
+      getParentId={(house) => house.id}
+      getParentName={(house) => house.name}
+      getChildId={(room) => room.id}
+      getChildName={(room) => room.name}
+      invalid={invalid}
+      requireChildSelection
+      isParentVisible={(house) => Boolean(house.visible)}
+      isChildVisible={(room) => Boolean(room.visible)}
+    />
   );
 }

--- a/src/components/HierarchicalSelector.tsx
+++ b/src/components/HierarchicalSelector.tsx
@@ -1,0 +1,127 @@
+import { ReactNode } from 'react';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+
+interface BasicItem {
+  id: string;
+  name: string;
+  visible?: boolean;
+}
+
+interface HierarchicalSelectorProps<TParent extends BasicItem, TChild extends BasicItem> {
+  label: string;
+  labelFor?: string;
+  placeholder: string;
+  parents: TParent[];
+  selectedParent: string;
+  selectedChild: string;
+  onSelectionChange: (parentId: string, childId: string) => void;
+  getChildren: (parent: TParent) => TChild[];
+  getParentId: (parent: TParent) => string;
+  getParentName: (parent: TParent) => string;
+  getChildId: (child: TChild) => string;
+  getChildName: (child: TChild) => string;
+  invalid?: boolean;
+  includeGeneralOption?: boolean;
+  requireChildSelection?: boolean;
+  isParentVisible?: (parent: TParent) => boolean;
+  isChildVisible?: (child: TChild) => boolean;
+  renderParentHeader?: (parent: TParent) => ReactNode;
+  renderGeneralLabel?: (parent: TParent) => ReactNode;
+}
+
+export function HierarchicalSelector<
+  TParent extends BasicItem,
+  TChild extends BasicItem,
+>({
+  label,
+  labelFor,
+  placeholder,
+  parents,
+  selectedParent,
+  selectedChild,
+  onSelectionChange,
+  getChildren,
+  getParentId,
+  getParentName,
+  getChildId,
+  getChildName,
+  invalid = false,
+  includeGeneralOption = false,
+  requireChildSelection = false,
+  isParentVisible = (parent) => parent.visible !== false,
+  isChildVisible = (child) => child.visible !== false,
+  renderParentHeader = (parent) => getParentName(parent),
+  renderGeneralLabel = (parent) => `General ${getParentName(parent)}`,
+}: HierarchicalSelectorProps<TParent, TChild>) {
+  const hasParent = Boolean(selectedParent);
+  const hasChild = Boolean(selectedChild);
+  const shouldShowValue = requireChildSelection ? hasParent && hasChild : hasParent;
+  const currentValue = shouldShowValue
+    ? `${selectedParent}|${selectedChild || ''}`
+    : '';
+
+  const handleSelectionChange = (value: string) => {
+    if (!value) {
+      onSelectionChange('', '');
+      return;
+    }
+
+    const [parentId, childId = ''] = value.split('|');
+    onSelectionChange(parentId, childId);
+  };
+
+  return (
+    <div>
+      <Label htmlFor={labelFor}>{label}</Label>
+      <Select value={currentValue} onValueChange={handleSelectionChange}>
+        <SelectTrigger
+          className={cn(
+            currentValue ? undefined : 'text-muted-foreground',
+            invalid && 'border-destructive focus:ring-destructive',
+          )}
+        >
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {parents.filter(isParentVisible).map((parent) => {
+            const parentId = getParentId(parent);
+            const children = getChildren(parent).filter(isChildVisible);
+
+            return (
+              <div key={parentId}>
+                <div className="px-2 py-1 text-sm font-medium text-muted-foreground bg-muted">
+                  {renderParentHeader(parent)}
+                </div>
+                {includeGeneralOption && (
+                  <SelectItem value={`${parentId}|`} className="pl-6 font-medium">
+                    {renderGeneralLabel(parent)}
+                  </SelectItem>
+                )}
+                {children.map((child) => {
+                  const childId = getChildId(child);
+                  return (
+                    <SelectItem
+                      key={`${parentId}|${childId}`}
+                      value={`${parentId}|${childId}`}
+                      className="pl-6"
+                    >
+                      {getChildName(child)}
+                    </SelectItem>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `HierarchicalSelector` component to encapsulate the parent/child select UI with validation handling
- refactor the category and house-room selectors to delegate to the shared component while preserving labels, placeholders, and visibility filters

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ca846c3e1483259297ca68a6a91301