### PR TITLE
feat: use shared currency formatter

### DIFF
--- a/src/components/ItemsList.tsx
+++ b/src/components/ItemsList.tsx
@@ -8,6 +8,7 @@ import { DecorItem } from '@/types/inventory';
 import { ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
 import { useSettingsState } from '@/hooks/useSettingsState';
 import { sortInventoryItems } from '@/lib/sortUtils';
+import { formatCurrencySafe } from '@/lib/currencyUtils';
 
 interface ItemsListProps {
   items: DecorItem[];
@@ -45,15 +46,6 @@ export function ItemsList({
   const activeSortDirection = sortDirection ?? internalSortDirection;
   const { houses, categories } = useSettingsState();
   const lastIndex = useRef<number | null>(null);
-
-  const formatCurrency = (value?: number, currency?: string) => {
-    if (!value) return '-';
-    const formatter = new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: currency || 'EUR',
-    });
-    return formatter.format(value);
-  };
 
   const handleSort = (field: SortField) => {
     if (onSort) {
@@ -203,7 +195,10 @@ export function ItemsList({
                   <div className="flex gap-2">
                     {item.valuation && (
                       <Badge variant="outline">
-                        {formatCurrency(item.valuation, item.valuationCurrency)}
+                        {formatCurrencySafe(
+                          item.valuation,
+                          item.valuationCurrency,
+                        )}
                       </Badge>
                     )}
                   </div>

--- a/src/components/ItemsTable.tsx
+++ b/src/components/ItemsTable.tsx
@@ -13,6 +13,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { cn } from '@/lib/utils';
 import { ArrowUpDown, ChevronUp, ChevronDown } from 'lucide-react';
 import { DecorItem } from '@/types/inventory';
+import { formatCurrencySafe } from '@/lib/currencyUtils';
 
 interface ItemsTableProps {
   items: DecorItem[];
@@ -34,15 +35,6 @@ export function ItemsTable({
   onSelectionChange,
 }: ItemsTableProps) {
   const lastIndex = useRef<number | null>(null);
-
-  const formatCurrency = (value?: number, currency?: string) => {
-    if (!value) return '-';
-    const formatter = new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: currency || 'EUR',
-    });
-    return formatter.format(value);
-  };
 
   const handleSort = (field: string) => {
     if (onSort) {
@@ -180,7 +172,7 @@ export function ItemsTable({
                 </div>
               </TableCell>
               <TableCell className="text-right">
-                {formatCurrency(item.valuation, item.valuationCurrency)}
+                {formatCurrencySafe(item.valuation, item.valuationCurrency)}
               </TableCell>
             </TableRow>
           ))}

--- a/src/lib/currencyUtils.ts
+++ b/src/lib/currencyUtils.ts
@@ -9,9 +9,12 @@ const currencyFormats: Record<string, { locale: string; symbol: string }> = {
 
 export function formatCurrency(amount: number, currencyCode: string): string {
   const format = currencyFormats[currencyCode];
-  
+
   if (!format) {
-    return `${currencyCode} ${amount.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+    return `${currencyCode} ${amount.toLocaleString('en-GB', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })}`;
   }
 
   return new Intl.NumberFormat(format.locale, {
@@ -20,6 +23,39 @@ export function formatCurrency(amount: number, currencyCode: string): string {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(amount);
+}
+
+interface FormatCurrencySafeOptions {
+  fallbackCurrency?: string;
+}
+
+export function formatCurrencySafe(
+  amount?: number | null,
+  currencyCode?: string | null,
+  options: FormatCurrencySafeOptions = {},
+): string {
+  if (typeof amount !== 'number' || !Number.isFinite(amount)) {
+    return '-';
+  }
+
+  const providedCurrency =
+    typeof currencyCode === 'string' && currencyCode.trim().length > 0
+      ? currencyCode
+      : undefined;
+
+  const fallbackCurrency =
+    typeof options.fallbackCurrency === 'string' &&
+    options.fallbackCurrency.trim().length > 0
+      ? options.fallbackCurrency
+      : undefined;
+
+  const resolvedCurrency = providedCurrency ?? fallbackCurrency ?? 'EUR';
+
+  if (!resolvedCurrency) {
+    return '-';
+  }
+
+  return formatCurrency(amount, resolvedCurrency);
 }
 
 export function formatNumber(value: number, decimals: number = 0): string {


### PR DESCRIPTION
## Summary
- add a shared `formatCurrencySafe` helper that returns a fallback dash when amounts or currencies are missing
- update the item list and table views to rely on the shared formatter instead of local helpers

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ca8499f5908325a9629e1e5bb7c6dc