### PR TITLE
Remove redundant theme wrapper

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,10 @@
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
-import { ThemeProvider } from './components/ThemeProvider';
 import { ServiceProvider } from './context/ServiceProvider';
 
 createRoot(document.getElementById('root')!).render(
-  <ThemeProvider>
-    <ServiceProvider>
-      <App />
-    </ServiceProvider>
-  </ThemeProvider>,
+  <ServiceProvider>
+    <App />
+  </ServiceProvider>,
 );


### PR DESCRIPTION
## Summary
- remove the extra `ThemeProvider` wrapper from `src/main.tsx` so the entry point only uses the provider defined in `App`

## Testing
- npm run lint
- npx eslint . --fix
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ca9626de048325a065998ee7450da8