### PR TITLE
Standardize API auth headers

### DIFF
--- a/src/lib/api/categories.ts
+++ b/src/lib/api/categories.ts
@@ -3,13 +3,12 @@ import {
   SubcategoryConfig,
   categoryConfigs,
 } from '@/types/inventory';
-import { API_URL, API_KEY } from './common';
+import { API_URL, withAuthHeaders } from './common';
 
 function buildHeaders(contentType?: string) {
   const headers: Record<string, string> = {};
   if (contentType) headers['Content-Type'] = contentType;
-  if (API_KEY) headers['X-API-Key'] = API_KEY;
-  return headers;
+  return withAuthHeaders(headers);
 }
 
 function getAllCategories(): CategoryConfig[] {
@@ -96,6 +95,7 @@ export async function deleteCategory(id: string) {
   try {
     const response = await fetch(`${API_URL}/categories/${id}`, {
       method: 'DELETE',
+      headers: buildHeaders(),
     });
     if (!response.ok) throw new Error('Failed to delete category');
     saveLocalCategories(getAllCategories().filter((c) => c.id !== id));
@@ -194,7 +194,10 @@ export async function deleteSubcategory(
   try {
     const response = await fetch(
       `${API_URL}/categories/${categoryId}/subcategories/${subcategoryId}`,
-      { method: 'DELETE' },
+      {
+        method: 'DELETE',
+        headers: buildHeaders(),
+      },
     );
     if (!response.ok) throw new Error('Failed to delete subcategory');
     const categories = getAllCategories().map((c) =>

--- a/src/lib/api/common.ts
+++ b/src/lib/api/common.ts
@@ -1,4 +1,18 @@
 
-export const API_URL = import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_API_URL || 'http://localhost:8000';
+export const API_URL =
+  import.meta.env.VITE_API_BASE_URL ||
+  import.meta.env.VITE_API_URL ||
+  'http://localhost:8000';
 export const API_KEY = import.meta.env.VITE_API_KEY;
-export const API_HEALTH_PATH = import.meta.env.VITE_API_HEALTH_PATH || '/health';
+export const API_HEALTH_PATH =
+  import.meta.env.VITE_API_HEALTH_PATH || '/health';
+
+export function withAuthHeaders(
+  base: Record<string, string> = {},
+): Record<string, string> {
+  const headers = { ...base };
+  if (API_KEY) {
+    headers.Authorization = `Bearer ${API_KEY}`;
+  }
+  return headers;
+}

--- a/src/lib/api/houses.ts
+++ b/src/lib/api/houses.ts
@@ -1,11 +1,10 @@
 import { HouseConfig, defaultHouses } from '@/types/inventory';
-import { API_URL, API_KEY } from './common';
+import { API_URL, withAuthHeaders } from './common';
 
 function buildHeaders(contentType?: string) {
   const headers: Record<string, string> = {};
   if (contentType) headers['Content-Type'] = contentType;
-  if (API_KEY) headers['X-API-Key'] = API_KEY;
-  return headers;
+  return withAuthHeaders(headers);
 }
 
 function getAllHouses(): HouseConfig[] {
@@ -100,6 +99,7 @@ export async function deleteHouse(id: string) {
   try {
     const response = await fetch(`${API_URL}/houses/${id}`, {
       method: 'DELETE',
+      headers: buildHeaders(),
     });
     if (!response.ok) throw new Error('Failed to delete house');
     const houses = getAllHouses().map((h) =>

--- a/src/lib/api/items.ts
+++ b/src/lib/api/items.ts
@@ -8,20 +8,10 @@ import {
 import { testDecorItems } from '@/data/testData';
 import { testBooks } from '@/data/booksTestData';
 import { testMusic } from '@/data/musicTestData';
-import { API_URL, API_KEY } from './common';
+import { API_URL, withAuthHeaders } from './common';
 
 const isApiConfigured = () => {
   return !!API_URL;
-};
-
-const withOptionalAuth = (
-  base: Record<string, string> = {},
-): Record<string, string> => {
-  const headers = { ...base };
-  if (API_KEY) {
-    headers.Authorization = `Bearer ${API_KEY}`;
-  }
-  return headers;
 };
 
 const isTestDataEnabled = () => {
@@ -129,7 +119,7 @@ export async function fetchDecorItems(): Promise<DecorItem[]> {
   
   try {
     const response = await fetch(`${API_URL}/items`, {
-      headers: withOptionalAuth({ 'Content-Type': 'application/json' }),
+      headers: withAuthHeaders({ 'Content-Type': 'application/json' }),
     });
     if (!response.ok) throw new Error('API request failed');
     return await response.json();
@@ -156,7 +146,7 @@ export async function fetchDecorItem(
   
   try {
     const response = await fetch(`${API_URL}/items/${id}`, {
-      headers: withOptionalAuth({ 'Content-Type': 'application/json' }),
+      headers: withAuthHeaders({ 'Content-Type': 'application/json' }),
     });
     if (!response.ok) throw new Error('Failed to fetch item');
     return await response.json();
@@ -179,7 +169,7 @@ export async function fetchBookItems(): Promise<BookItem[]> {
   
   try {
     const response = await fetch(`${API_URL}/books`, {
-      headers: withOptionalAuth({ 'Content-Type': 'application/json' }),
+      headers: withAuthHeaders({ 'Content-Type': 'application/json' }),
     });
     if (!response.ok) throw new Error('API request failed');
     return await response.json();
@@ -202,7 +192,7 @@ export async function fetchMusicItems(): Promise<MusicItem[]> {
   
   try {
     const response = await fetch(`${API_URL}/music`, {
-      headers: withOptionalAuth({ 'Content-Type': 'application/json' }),
+      headers: withAuthHeaders({ 'Content-Type': 'application/json' }),
     });
     if (!response.ok) throw new Error('API request failed');
     return await response.json();
@@ -231,7 +221,7 @@ export async function createDecorItem(
   try {
     const response = await fetch(`${API_URL}/items`, {
       method: 'POST',
-      headers: withOptionalAuth({ 'Content-Type': 'application/json' }),
+      headers: withAuthHeaders({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(input),
     });
     if (!response.ok) throw new Error('Failed to create item');
@@ -270,7 +260,7 @@ export async function updateDecorItem(
   try {
     const response = await fetch(`${API_URL}/items/${id}`, {
       method: 'PUT',
-      headers: withOptionalAuth({ 'Content-Type': 'application/json' }),
+      headers: withAuthHeaders({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(input),
     });
     if (!response.ok) throw new Error('Failed to update item');
@@ -295,7 +285,7 @@ export async function deleteDecorItem(id: number): Promise<void> {
   try {
     const response = await fetch(`${API_URL}/items/${id}`, {
       method: 'DELETE',
-      headers: withOptionalAuth(),
+      headers: withAuthHeaders(),
     });
     if (!response.ok) throw new Error('Failed to delete item');
   } catch (error) {
@@ -330,7 +320,7 @@ export async function restoreDecorItem(
   try {
     const response = await fetch(`${API_URL}/items/${id}/restore`, {
       method: 'POST',
-      headers: withOptionalAuth({ 'Content-Type': 'application/json' }),
+      headers: withAuthHeaders({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(version),
     });
     if (!response.ok) throw new Error('Failed to restore item');

--- a/src/lib/api/roomTypes.ts
+++ b/src/lib/api/roomTypes.ts
@@ -1,4 +1,4 @@
-import { API_URL, API_KEY } from './common';
+import { API_URL, withAuthHeaders } from './common';
 
 export interface RoomType {
   id: string;
@@ -6,9 +6,7 @@ export interface RoomType {
 }
 
 function buildHeaders() {
-  const headers: Record<string, string> = {};
-  if (API_KEY) headers['X-API-Key'] = API_KEY;
-  return headers;
+  return withAuthHeaders();
 }
 
 export async function fetchRoomTypes(): Promise<RoomType[]> {

--- a/src/lib/api/rooms.ts
+++ b/src/lib/api/rooms.ts
@@ -1,12 +1,11 @@
 import { RoomConfig } from '@/types/inventory';
-import { API_URL, API_KEY } from './common';
+import { API_URL, withAuthHeaders } from './common';
 import { getAllHouses, saveLocalHouses } from './houses';
 
 function buildHeaders(contentType?: string) {
   const headers: Record<string, string> = {};
   if (contentType) headers['Content-Type'] = contentType;
-  if (API_KEY) headers['X-API-Key'] = API_KEY;
-  return headers;
+  return withAuthHeaders(headers);
 }
 
 export async function addRoom(houseId: string, room: RoomConfig) {
@@ -95,6 +94,7 @@ export async function deleteRoom(houseId: string, roomId: string) {
       `${API_URL}/houses/${houseId}/rooms/${roomId}`,
       {
         method: 'DELETE',
+        headers: buildHeaders(),
       },
     );
     if (!response.ok) throw new Error('Failed to delete room');


### PR DESCRIPTION
## Summary
- add a shared helper in `src/lib/api/common.ts` that applies the API key as a bearer token header
- update items, categories, houses, rooms, and room types API clients to consume the helper and send the Authorization header on every request

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ca96fda9c08325bb694dded10cf5ad